### PR TITLE
pageFunction and pageLoad maximum limit seconds removed

### DIFF
--- a/cheerio-scraper/INPUT_SCHEMA.json
+++ b/cheerio-scraper/INPUT_SCHEMA.json
@@ -173,7 +173,6 @@
 			"description": "The maximum amount of time the scraper will wait for a web page to load, in seconds. If the web page does not load in this timeframe, it is considered to have failed and will be retried (subject to <b>Max page retries</b>), similarly as with other page load errors.",
 			"minimum": 1,
 			"default": 60,
-			"maximum": 360,
 			"unit": "seconds"
 		},
 		"pageFunctionTimeoutSecs": {
@@ -182,7 +181,6 @@
 			"description": "The maximum amount of time the scraper will wait for the <b>Page function</b> to execute, in seconds. It is always a good idea to set this limit, to ensure that unexpected behavior in page function will not get the scraper stuck.",
 			"minimum": 1,
 			"default": 60,
-			"maximum": 360,
 			"unit": "seconds"
 		},
 		"debugLog": {

--- a/puppeteer-scraper/INPUT_SCHEMA.json
+++ b/puppeteer-scraper/INPUT_SCHEMA.json
@@ -197,7 +197,6 @@
       "description": "Maximum time the scraper will allow a web page to load in seconds.",
       "minimum": 1,
       "default": 60,
-      "maximum": 360,
       "unit": "secs"
     },
     "pageFunctionTimeoutSecs": {
@@ -206,7 +205,6 @@
       "description": "Maximum time the scraper will wait for the page function to execute in seconds.",
       "minimum": 1,
       "default": 60,
-      "maximum": 360,
       "unit": "secs"
     },
     "waitUntil": {

--- a/web-scraper/INPUT_SCHEMA.json
+++ b/web-scraper/INPUT_SCHEMA.json
@@ -201,7 +201,6 @@
             "description": "The maximum amount of time the scraper will wait for a web page to load, in seconds. If the web page does not load in this timeframe, it is considered to have failed and will be retried (subject to <b>Max page retries</b>), similarly as with other page load errors.",
             "minimum": 1,
             "default": 60,
-            "maximum": 360,
             "unit": "seconds"
         },
         "pageFunctionTimeoutSecs": {
@@ -210,7 +209,6 @@
             "description": "The maximum amount of time the scraper will wait for <b>Page function</b> to execute, in seconds. It's a good idea to set this limit, to ensure that unexpected behavior in page function will not get the scraper stuck.",
             "minimum": 1,
             "default": 60,
-            "maximum": 360,
             "unit": "seconds"
         },
         "waitUntil": {


### PR DESCRIPTION
Maximum limit removed for `pageFunction` timeout and `pageLoad` timeout (both were set to 360)