### PR TITLE
Option useRequestQueue is deprecated but still works

### DIFF
--- a/cheerio-scraper/INPUT_SCHEMA.json
+++ b/cheerio-scraper/INPUT_SCHEMA.json
@@ -12,19 +12,12 @@
 			"prefill": [ { "url": "https://apify.com" } ],
 			"editor": "requestListSources"
 		},
-		"useRequestQueue": {
-			"title": "Use request queue",
-			"type": "boolean",
-			"description": "If enabled, the scraper will support adding new URLs to scrape on the fly, either using the <b>Link selector</b> and <b>Pseudo-URLs</b> options or by calling <code>context.enqueueRequest()</code> inside the <b>Page function</b>. Use of the request queue has some overheads, so only enable this option if you need to add URLs dynamically.",
-			"default": true,
-			"groupCaption": "Options",
-			"editor": "hidden"
-		},
 		"keepUrlFragments": {
 			"title": "URL #fragments identify unique pages",
 			"type": "boolean",
 			"description": "Indicates that URL fragments (e.g. <code>http://example.com<b>#fragment</b></code>) should be included when checking whether a URL has already been visited or not. Typically, URL fragments are used for page navigation only and therefore they should be ignored, as they don't identify separate pages. However, some single-page websites use URL fragments to display different pages; in such cases, this option should be enabled.",
-			"default": false
+			"default": false,
+			"groupCaption": "Options"
 		},
 		"pseudoUrls": {
 			"title": "Pseudo-URLs",
@@ -216,6 +209,12 @@
 			"type": "string",
 			"description": "Name of the request queue that will be used for storing requests. If left empty, the default request queue of the run will be used.",
 			"editor": "textfield"
+		},
+		"useRequestQueue": {
+			"title": "Use request queue",
+			"type": "boolean",
+			"description": "If enabled, the scraper will support adding new URLs to scrape on the fly, either using the <b>Link selector</b> and <b>Pseudo-URLs</b> options or by calling <code>context.enqueueRequest()</code> inside the <b>Page function</b>. Use of the request queue has some overheads, so only enable this option if you need to add URLs dynamically.",
+			"editor": "hidden"
 		}
 	},
 	"required": [ "startUrls", "pageFunction" ]

--- a/cheerio-scraper/INPUT_SCHEMA.json
+++ b/cheerio-scraper/INPUT_SCHEMA.json
@@ -17,7 +17,8 @@
 			"type": "boolean",
 			"description": "If enabled, the scraper will support adding new URLs to scrape on the fly, either using the <b>Link selector</b> and <b>Pseudo-URLs</b> options or by calling <code>context.enqueueRequest()</code> inside the <b>Page function</b>. Use of the request queue has some overheads, so only enable this option if you need to add URLs dynamically.",
 			"default": true,
-			"groupCaption": "Options"
+			"groupCaption": "Options",
+			"editor": "hidden"
 		},
 		"keepUrlFragments": {
 			"title": "URL #fragments identify unique pages",

--- a/cheerio-scraper/src/crawler_setup.js
+++ b/cheerio-scraper/src/crawler_setup.js
@@ -73,7 +73,7 @@ class CrawlerSetup {
         this.env = Apify.getEnv();
 
         // Validations
-        if (this.input.pseudoUrls.length && !this.input.useRequestQueue) {
+        if (this.input.pseudoUrls.length && this.input.useRequestQueue === false) {
             throw new Error('Cannot enqueue links using Pseudo-URLs without using a request queue. '
                 + 'Either enable the "Use request queue" option or '
                 + 'remove your Pseudo-URLs.');
@@ -123,8 +123,8 @@ class CrawlerSetup {
         this.requestList = await Apify.openRequestList('CHEERIO_SCRAPER', startUrls);
 
         // RequestQueue
-        if (!this.input.useRequestQueue) {
-            log.warning('Option useRequestQueue is deprecated. '
+        if (this.input.useRequestQueue === false) {
+            log.deprecated('Option useRequestQueue is deprecated. '
                 + 'The request queue is not going to be used now but this option will not be possible to set in the future.');
         } else {
             this.requestQueue = await Apify.openRequestQueue(this.requestQueueName);
@@ -267,7 +267,7 @@ class CrawlerSetup {
                 globalStore: this.globalStore,
                 requestQueue: this.requestQueue,
                 customData: this.input.customData,
-                useRequestQueue: this.input.useRequestQueue,
+                useRequestQueue: this.input.useRequestQueue !== false,
             },
             pageFunctionArguments: {
                 $,

--- a/cheerio-scraper/src/crawler_setup.js
+++ b/cheerio-scraper/src/crawler_setup.js
@@ -122,8 +122,13 @@ class CrawlerSetup {
         });
         this.requestList = await Apify.openRequestList('CHEERIO_SCRAPER', startUrls);
 
-        // RequestQueue if selected
-        if (this.input.useRequestQueue) this.requestQueue = await Apify.openRequestQueue(this.requestQueueName);
+        // RequestQueue
+        if (!this.input.useRequestQueue) {
+            log.warning('Option useRequestQueue is deprecated. '
+                + 'The request queue is not going to be used now but this option will not be possible to set in the future.');
+        } else {
+            this.requestQueue = await Apify.openRequestQueue(this.requestQueueName);
+        }
 
         // Dataset
         this.dataset = await Apify.openDataset(this.datasetName);

--- a/puppeteer-scraper/INPUT_SCHEMA.json
+++ b/puppeteer-scraper/INPUT_SCHEMA.json
@@ -16,13 +16,6 @@
       ],
       "editor": "requestListSources"
     },
-    "useRequestQueue": {
-      "title": "Use request queue",
-      "type": "boolean",
-      "description": "Request queue enables recursive crawling and the use of Pseudo-URLs, Link selector and <code>context.enqueueRequest()</code>.",
-      "default": true,
-      "editor": "hidden"
-    },
     "pseudoUrls": {
       "title": "Pseudo-URLs",
       "type": "array",
@@ -260,6 +253,12 @@
       "type": "string",
       "description": "Name of the request queue that will be used for storing requests. If left empty, the default request queue of the run will be used.",
       "editor": "textfield"
+    },
+    "useRequestQueue": {
+      "title": "Use request queue",
+      "type": "boolean",
+      "description": "Request queue enables recursive crawling and the use of Pseudo-URLs, Link selector and <code>context.enqueueRequest()</code>.",
+      "editor": "hidden"
     }
   },
   "required": []

--- a/puppeteer-scraper/INPUT_SCHEMA.json
+++ b/puppeteer-scraper/INPUT_SCHEMA.json
@@ -20,7 +20,8 @@
       "title": "Use request queue",
       "type": "boolean",
       "description": "Request queue enables recursive crawling and the use of Pseudo-URLs, Link selector and <code>context.enqueueRequest()</code>.",
-      "default": true
+      "default": true,
+      "editor": "hidden"
     },
     "pseudoUrls": {
       "title": "Pseudo-URLs",

--- a/puppeteer-scraper/src/crawler_setup.js
+++ b/puppeteer-scraper/src/crawler_setup.js
@@ -142,8 +142,13 @@ class CrawlerSetup {
         });
         this.requestList = await Apify.openRequestList('PUPPETEER_SCRAPER', startUrls);
 
-        // RequestQueue if selected
-        if (this.input.useRequestQueue) this.requestQueue = await Apify.openRequestQueue(this.requestQueueName);
+        // RequestQueue
+        if (!this.input.useRequestQueue) {
+            log.warning('Option useRequestQueue is deprecated. '
+                + 'The request queue is not going to be used now but this option will not be possible to set in the future.');
+        } else {
+            this.requestQueue = await Apify.openRequestQueue(this.requestQueueName);
+        }
 
         // Dataset
         this.dataset = await Apify.openDataset(this.datasetName);

--- a/puppeteer-scraper/src/crawler_setup.js
+++ b/puppeteer-scraper/src/crawler_setup.js
@@ -78,7 +78,7 @@ class CrawlerSetup {
         this.env = Apify.getEnv();
 
         // Validations
-        if (this.input.pseudoUrls.length && !this.input.useRequestQueue) {
+        if (this.input.pseudoUrls.length && this.input.useRequestQueue === false) {
             throw new Error('Cannot enqueue links using Pseudo-URLs without using a request queue. '
                 + 'Either enable the "Use request queue" option or '
                 + 'remove your Pseudo-URLs.');
@@ -143,7 +143,7 @@ class CrawlerSetup {
         this.requestList = await Apify.openRequestList('PUPPETEER_SCRAPER', startUrls);
 
         // RequestQueue
-        if (!this.input.useRequestQueue) {
+        if (this.input.useRequestQueue === false) {
             log.warning('Option useRequestQueue is deprecated. '
                 + 'The request queue is not going to be used now but this option will not be possible to set in the future.');
         } else {
@@ -293,7 +293,7 @@ class CrawlerSetup {
                 globalStore: this.globalStore,
                 requestQueue: this.requestQueue,
                 customData: this.input.customData,
-                useRequestQueue: this.input.useRequestQueue,
+                useRequestQueue: this.input.useRequestQueue !== false,
             },
             pageFunctionArguments: {
                 page,

--- a/web-scraper/INPUT_SCHEMA.json
+++ b/web-scraper/INPUT_SCHEMA.json
@@ -31,7 +31,8 @@
             "type": "boolean",
             "description": "If enabled, the scraper will support adding new URLs to scrape on the fly, either using the <b>Link selector</b> and <b>Pseudo-URLs</b> options or by calling <code>context.enqueueRequest()</code> inside <b>Page function</b>. Use of the request queue has some overheads, so only enable this option if you need to add URLs dynamically.",
             "default": true,
-            "groupCaption": "Options"
+            "groupCaption": "Options",
+            "editor": "hidden"
         },
         "keepUrlFragments": {
             "title": "URL #fragments identify unique pages",

--- a/web-scraper/INPUT_SCHEMA.json
+++ b/web-scraper/INPUT_SCHEMA.json
@@ -26,19 +26,12 @@
             ],
             "editor": "requestListSources"
         },
-        "useRequestQueue": {
-            "title": "Use request queue",
-            "type": "boolean",
-            "description": "If enabled, the scraper will support adding new URLs to scrape on the fly, either using the <b>Link selector</b> and <b>Pseudo-URLs</b> options or by calling <code>context.enqueueRequest()</code> inside <b>Page function</b>. Use of the request queue has some overheads, so only enable this option if you need to add URLs dynamically.",
-            "default": true,
-            "groupCaption": "Options",
-            "editor": "hidden"
-        },
         "keepUrlFragments": {
             "title": "URL #fragments identify unique pages",
             "type": "boolean",
             "description": "Indicates that URL fragments (e.g. <code>http://example.com<b>#fragment</b></code>) should be included when checking whether a URL has already been visited or not. Typically, URL fragments are used for page navigation only and therefore they should be ignored, as they don't identify separate pages. However, some single-page websites use URL fragments to display different pages; in such a case, this option should be enabled.",
-            "default": false
+            "default": false,
+            "groupCaption": "Options"
         },
         "linkSelector": {
             "title": "Link selector",
@@ -279,6 +272,12 @@
             "type": "string",
             "description": "Name of the request queue that will be used for storing requests. If left empty, the default request queue of the run will be used.",
             "editor": "textfield"
+        },
+        "useRequestQueue": {
+            "title": "Use request queue",
+            "type": "boolean",
+            "description": "If enabled, the scraper will support adding new URLs to scrape on the fly, either using the <b>Link selector</b> and <b>Pseudo-URLs</b> options or by calling <code>context.enqueueRequest()</code> inside <b>Page function</b>. Use of the request queue has some overheads, so only enable this option if you need to add URLs dynamically.",
+            "editor": "hidden"
         }
     },
     "required": ["startUrls", "pageFunction"]

--- a/web-scraper/src/crawler_setup.js
+++ b/web-scraper/src/crawler_setup.js
@@ -96,7 +96,7 @@ class CrawlerSetup {
         this.env = Apify.getEnv();
 
         // Validations
-        if (this.input.pseudoUrls.length && !this.input.useRequestQueue) {
+        if (this.input.pseudoUrls.length && this.input.useRequestQueue === false) {
             throw new Error('Cannot enqueue links using Pseudo-URLs without using a request queue. '
                 + 'Either enable the "Use request queue" option or '
                 + 'remove your Pseudo-URLs.');
@@ -159,7 +159,7 @@ class CrawlerSetup {
         this.requestList = await Apify.openRequestList('WEB_SCRAPER', startUrls);
 
         // RequestQueue
-        if (!this.input.useRequestQueue) {
+        if (this.input.useRequestQueue === false) {
             log.warning('Option useRequestQueue is deprecated. '
                 + 'The request queue is not going to be used now but this option will not be possible to set in the future.');
         } else {
@@ -359,7 +359,7 @@ class CrawlerSetup {
                 rawInput: this.rawInput,
                 env: this.env,
                 customData: this.input.customData,
-                useRequestQueue: this.input.useRequestQueue,
+                useRequestQueue: this.input.useRequestQueue !== false,
                 injectJQuery: this.input.injectJQuery,
                 injectUnderscore: this.input.injectUnderscore,
                 META_KEY,

--- a/web-scraper/src/crawler_setup.js
+++ b/web-scraper/src/crawler_setup.js
@@ -158,8 +158,13 @@ class CrawlerSetup {
         });
         this.requestList = await Apify.openRequestList('WEB_SCRAPER', startUrls);
 
-        // RequestQueue if selected
-        if (this.input.useRequestQueue) this.requestQueue = await Apify.openRequestQueue(this.requestQueueName);
+        // RequestQueue
+        if (!this.input.useRequestQueue) {
+            log.warning('Option useRequestQueue is deprecated. '
+                + 'The request queue is not going to be used now but this option will not be possible to set in the future.');
+        } else {
+            this.requestQueue = await Apify.openRequestQueue(this.requestQueueName);
+        }
 
         // Dataset
         this.dataset = await Apify.openDataset(this.datasetName);


### PR DESCRIPTION
Option `useRequestQueue` is now not displayed in the input of scrapers.

It is **deprecated** but still **works**. Input schema validation still works and this option is defaultly set to `true` so no need to validate in code.