### PR TITLE
Web scraper: does not use sessionPool in dev mode

### DIFF
--- a/web-scraper/INPUT_SCHEMA.json
+++ b/web-scraper/INPUT_SCHEMA.json
@@ -8,7 +8,7 @@
             "sectionCaption": "Basic configuration",
             "title": "Run mode",
             "type": "string",
-            "description": "This property indicates the scraper's mode of operation. In DEVELOPMENT mode, the scraper ignores page timeouts, opens pages one by one and enables debugging via Chrome DevTools. Open the live view tab or the container URL to access the debugger. Further debugging options can be configured in the Advanced configuration section. PRODUCTION mode disables debugging and enables timeouts and concurrency. <br><br>For details, see <a href='https://apify.com/apify/web-scraper#run-mode' target='_blank' rel='noopener'>Run mode</a> in README.",
+            "description": "This property indicates the scraper's mode of operation. In DEVELOPMENT mode, the scraper ignores page timeouts, doesn't use sessionPool, opens pages one by one and enables debugging via Chrome DevTools.  Open the live view tab or the container URL to access the debugger. Further debugging options can be configured in the Advanced configuration section. PRODUCTION mode disables debugging and enables timeouts and concurrency. <br><br>For details, see <a href='https://apify.com/apify/web-scraper#run-mode' target='_blank' rel='noopener'>Run mode</a> in README.",
             "default": "PRODUCTION",
             "prefill": "DEVELOPMENT",
             "editor": "select",

--- a/web-scraper/src/crawler_setup.js
+++ b/web-scraper/src/crawler_setup.js
@@ -222,7 +222,7 @@ class CrawlerSetup {
                 args,
             },
             useSessionPool: !this.isDevRun,
-            persistCookiesPerSession: true,
+            persistCookiesPerSession: !this.isDevRun,
             sessionPoolOptions: {
                 persistStateKeyValueStoreId: this.input.sessionPoolName ? SESSION_STORE_NAME : undefined,
                 persistStateKey: this.input.sessionPoolName,
@@ -273,6 +273,7 @@ class CrawlerSetup {
             if (cookiesToSet && cookiesToSet.length) {
                 // setting initial cookies that are not already in the session and page
                 if (session) session.setPuppeteerCookies(cookiesToSet, request.url);
+                // TODO: We have to change this when there is an option to define blocked status codes in sessionPool
                 await page.setCookie(...cookiesToSet);
             }
         }

--- a/web-scraper/src/crawler_setup.js
+++ b/web-scraper/src/crawler_setup.js
@@ -216,7 +216,7 @@ class CrawlerSetup {
                 stealth: this.input.useStealth,
                 args,
             },
-            useSessionPool: true,
+            useSessionPool: !this.isDevRun,
             persistCookiesPerSession: true,
             sessionPoolOptions: {
                 persistStateKeyValueStoreId: this.input.sessionPoolName ? SESSION_STORE_NAME : undefined,

--- a/web-scraper/src/crawler_setup.js
+++ b/web-scraper/src/crawler_setup.js
@@ -267,10 +267,12 @@ class CrawlerSetup {
 
         // Add initial cookies, if any.
         if (this.input.initialCookies && this.input.initialCookies.length) {
-            const cookiesToSet = tools.getMissingCookiesFromSession(session, this.input.initialCookies, request.url);
+            const cookiesToSet = session
+                ? tools.getMissingCookiesFromSession(session, this.input.initialCookies, request.url)
+                : this.input.initialCookies;
             if (cookiesToSet && cookiesToSet.length) {
                 // setting initial cookies that are not already in the session and page
-                session.setPuppeteerCookies(cookiesToSet, request.url);
+                if (session) session.setPuppeteerCookies(cookiesToSet, request.url);
                 await page.setCookie(...cookiesToSet);
             }
         }

--- a/web-scraper/src/crawler_setup.js
+++ b/web-scraper/src/crawler_setup.js
@@ -272,8 +272,8 @@ class CrawlerSetup {
                 : this.input.initialCookies;
             if (cookiesToSet && cookiesToSet.length) {
                 // setting initial cookies that are not already in the session and page
-                if (session) session.setPuppeteerCookies(cookiesToSet, request.url);
-                // TODO: We have to change this when there is an option to define blocked status codes in sessionPool
+                // eslint-disable-next-line max-len
+                if (session) session.setPuppeteerCookies(cookiesToSet, request.url); // TODO: We can remove the condition when there is an option to define blocked status codes in sessionPool
                 await page.setCookie(...cookiesToSet);
             }
         }
@@ -589,8 +589,9 @@ function logDevRunWarning() {
     log.warning(`
 *****************************************************************
 *          Web Scraper is running in DEVELOPMENT MODE!          *
-*  Concurrency is limited, timeouts are increased and debugger  *
-*  is enabled. If you want full control and performance switch  *
+*       Concurrency is limited, sessionPool is not available,   *
+*       timeouts are increased and debugger is enabled.         *
+*       If you want full control and performance switch         *
 *                    Run type to PRODUCTION!                    *
 *****************************************************************
 `);


### PR DESCRIPTION
Options `useSessionPool` and `persistCookiesPerSession` are not available in `DEVELOPMENT` mode for the `web scraper`.