### PR TITLE
docs: support large run count numbers (multiple separators)

### DIFF
--- a/docs/build/cheerio-scraper-tutorial.md
+++ b/docs/build/cheerio-scraper-tutorial.md
@@ -123,7 +123,7 @@ return {
         $('ul.ActorHeader-stats > li:nth-of-type(3)')
             .text()
             .match(/[\d,]+/)[0]
-            .replace(',', ''),
+            .replace(/,/g, ''),
     ),
 };
 ```
@@ -134,7 +134,10 @@ using a regular expression, but its type is still a `string`, so we finally conv
 
 > The numbers are formatted with commas as thousands separators (e.g. `'1,234,567'`), so to extract it, we
 > first use regular expression `/[\d,]+/` - it will search for consecutive number or comma characters.
-> Then we extract the match via `.match(/[\d,]+/)[0]` and finally remove the commas by calling `.replace(',', '')`.
+> Then we extract the match via `.match(/[\d,]+/)[0]` and finally remove all the commas by calling `.replace(/,/g, '')`.
+> We need to use `/,/g` with the global modifier to support large numbers with multiple separators, without it
+> we would replace only the very first occurrence.
+> 
 > This will give us a string (e.g. `'1234567'`) that can be converted via `Number` function.
 
 ### [](#wrapping-it-up) Wrapping it up
@@ -166,7 +169,7 @@ return {
         $('ul.ActorHeader-stats > li:nth-of-type(3)')
             .text()
             .match(/[\d,]+/)[0]
-            .replace(',', ''),
+            .replace(/,/g, ''),
     ),
 };
 ```
@@ -206,7 +209,7 @@ async function pageFunction(context) {
                 $('ul.ActorHeader-stats > li:nth-of-type(3)')
                     .text()
                     .match(/[\d,]+/)[0]
-                    .replace(',', ''),
+                    .replace(/,/g, ''),
             ),
         };
     }
@@ -367,7 +370,7 @@ async function pageFunction(context) {
                 $('ul.ActorHeader-stats > li:nth-of-type(3)')
                     .text()
                     .match(/[\d,]+/)[0]
-                    .replace(',', ''),
+                    .replace(/,/g, ''),
             ),
         };
     }
@@ -459,7 +462,7 @@ async function pageFunction(context) {
                 $('ul.ActorHeader-stats > li:nth-of-type(3)')
                     .text()
                     .match(/[\d,]+/)[0]
-                    .replace(',', ''),
+                    .replace(/,/g, ''),
             ),
         };
     }

--- a/docs/build/puppeteer-scraper-tutorial.md
+++ b/docs/build/puppeteer-scraper-tutorial.md
@@ -196,7 +196,10 @@ using a regular expression, but its type is still a `string`, so we finally conv
 
 > The numbers are formatted with commas as thousands separators (e.g. `'1,234,567'`), so to extract it, we
 > first use regular expression `/[\d,]+/` - it will search for consecutive number or comma characters.
-> Then we extract the match via `.match(/[\d,]+/)[0]` and finally remove the commas by calling `.replace(',', '')`.
+> Then we extract the match via `.match(/[\d,]+/)[0]` and finally remove all the commas by calling `.replace(/,/g, '')`.
+> We need to use `/,/g` with the global modifier to support large numbers with multiple separators, without it
+> we would replace only the very first occurrence.
+> 
 > This will give us a string (e.g. `'1234567'`) that can be converted via `Number` function.
 
 ### [](#wrapping-it-up) Wrapping it up
@@ -766,7 +769,7 @@ async function pageFunction(context) {
                     $('ul.ActorHeader-stats > li:nth-of-type(3)')
                         .text()
                         .match(/[\d,]+/)[0]
-                        .replace(',', ''),
+                        .replace(/,/g, ''),
                 ),
             };
         });

--- a/docs/build/web-scraper-tutorial.md
+++ b/docs/build/web-scraper-tutorial.md
@@ -121,7 +121,7 @@ return {
         $('ul.ActorHeader-stats > li:nth-of-type(3)')
             .text()
             .match(/[\d,]+/)[0]
-            .replace(',', ''),
+            .replace(/,/g, ''),
     ),
 };
 ```
@@ -132,7 +132,10 @@ using a regular expression, but its type is still a `string`, so we finally conv
 
 > The numbers are formatted with commas as thousands separators (e.g. `'1,234,567'`), so to extract it, we
 > first use regular expression `/[\d,]+/` - it will search for consecutive number or comma characters.
-> Then we extract the match via `.match(/[\d,]+/)[0]` and finally remove the commas by calling `.replace(',', '')`.
+> Then we extract the match via `.match(/[\d,]+/)[0]` and finally remove all the commas by calling `.replace(/,/g, '')`.
+> We need to use `/,/g` with the global modifier to support large numbers with multiple separators, without it
+> we would replace only the very first occurrence.
+> 
 > This will give us a string (e.g. `'1234567'`) that can be converted via `Number` function.
 
 ### [](#wrapping-it-up) Wrapping it up
@@ -161,7 +164,7 @@ return {
         $('ul.ActorHeader-stats > li:nth-of-type(3)')
             .text()
             .match(/[\d,]+/)[0]
-            .replace(',', ''),
+            .replace(/,/g, ''),
     ),
 };
 ```
@@ -202,7 +205,7 @@ async function pageFunction(context) {
                 $('ul.ActorHeader-stats > li:nth-of-type(3)')
                     .text()
                     .match(/[\d,]+/)[0]
-                    .replace(',', ''),
+                    .replace(/,/g, ''),
             ),
         };
     }
@@ -413,7 +416,7 @@ async function pageFunction(context) {
                 $('ul.ActorHeader-stats > li:nth-of-type(3)')
                     .text()
                     .match(/[\d,]+/)[0]
-                    .replace(',', ''),
+                    .replace(/,/g, ''),
             ),
         };
     }
@@ -567,7 +570,7 @@ async function pageFunction(context) {
                 $('ul.ActorHeader-stats > li:nth-of-type(3)')
                     .text()
                     .match(/[\d,]+/)[0]
-                    .replace(',', ''),
+                    .replace(/,/g, ''),
             ),
         };
     }

--- a/docs/cheerio-scraper/code/bonus.js
+++ b/docs/cheerio-scraper/code/bonus.js
@@ -48,7 +48,7 @@ async function pageFunction(context) {
                 $('ul.ActorHeader-stats > li:nth-of-type(3)')
                     .text()
                     .match(/[\d,]+/)[0]
-                    .replace(',', ''),
+                    .replace(/,/g, ''),
             ),
         };
     }

--- a/docs/cheerio-scraper/code/pagination.js
+++ b/docs/cheerio-scraper/code/pagination.js
@@ -43,7 +43,7 @@ async function pageFunction(context) {
                 $('ul.ActorHeader-stats > li:nth-of-type(3)')
                     .text()
                     .match(/[\d,]+/)[0]
-                    .replace(',', ''),
+                    .replace(/,/g, ''),
             ),
         };
     }

--- a/docs/cheerio-scraper/code/run-count.js
+++ b/docs/cheerio-scraper/code/run-count.js
@@ -10,6 +10,6 @@ return {
         $('ul.ActorHeader-stats > li:nth-of-type(3)')
             .text()
             .match(/[\d,]+/)[0]
-            .replace(',', ''),
+            .replace(/,/g, ''),
     ),
 };

--- a/docs/cheerio-scraper/code/wrapping-it-up-1.js
+++ b/docs/cheerio-scraper/code/wrapping-it-up-1.js
@@ -21,6 +21,6 @@ return {
         $('ul.ActorHeader-stats > li:nth-of-type(3)')
             .text()
             .match(/[\d,]+/)[0]
-            .replace(',', ''),
+            .replace(/,/g, ''),
     ),
 };

--- a/docs/cheerio-scraper/code/wrapping-it-up-2.js
+++ b/docs/cheerio-scraper/code/wrapping-it-up-2.js
@@ -30,7 +30,7 @@ async function pageFunction(context) {
                 $('ul.ActorHeader-stats > li:nth-of-type(3)')
                     .text()
                     .match(/[\d,]+/)[0]
-                    .replace(',', ''),
+                    .replace(/,/g, ''),
             ),
         };
     }

--- a/docs/common/partials/run-count.md
+++ b/docs/common/partials/run-count.md
@@ -11,5 +11,8 @@ using a regular expression, but its type is still a `string`, so we finally conv
 
 > The numbers are formatted with commas as thousands separators (e.g. `'1,234,567'`), so to extract it, we
 > first use regular expression `/[\d,]+/` - it will search for consecutive number or comma characters.
-> Then we extract the match via `.match(/[\d,]+/)[0]` and finally remove the commas by calling `.replace(',', '')`.
+> Then we extract the match via `.match(/[\d,]+/)[0]` and finally remove all the commas by calling `.replace(/,/g, '')`.
+> We need to use `/,/g` with the global modifier to support large numbers with multiple separators, without it
+> we would replace only the very first occurrence.
+> 
 > This will give us a string (e.g. `'1234567'`) that can be converted via `Number` function.

--- a/docs/puppeteer-scraper/code/jquery.js
+++ b/docs/puppeteer-scraper/code/jquery.js
@@ -59,7 +59,7 @@ async function pageFunction(context) {
                     $('ul.ActorHeader-stats > li:nth-of-type(3)')
                         .text()
                         .match(/[\d,]+/)[0]
-                        .replace(',', ''),
+                        .replace(/,/g, ''),
                 ),
             };
         });

--- a/docs/web-scraper/code/bonus.js
+++ b/docs/web-scraper/code/bonus.js
@@ -57,7 +57,7 @@ async function pageFunction(context) {
                 $('ul.ActorHeader-stats > li:nth-of-type(3)')
                     .text()
                     .match(/[\d,]+/)[0]
-                    .replace(',', ''),
+                    .replace(/,/g, ''),
             ),
         };
     }

--- a/docs/web-scraper/code/pagination.js
+++ b/docs/web-scraper/code/pagination.js
@@ -53,7 +53,7 @@ async function pageFunction(context) {
                 $('ul.ActorHeader-stats > li:nth-of-type(3)')
                     .text()
                     .match(/[\d,]+/)[0]
-                    .replace(',', ''),
+                    .replace(/,/g, ''),
             ),
         };
     }

--- a/docs/web-scraper/code/run-count.js
+++ b/docs/web-scraper/code/run-count.js
@@ -10,6 +10,6 @@ return {
         $('ul.ActorHeader-stats > li:nth-of-type(3)')
             .text()
             .match(/[\d,]+/)[0]
-            .replace(',', ''),
+            .replace(/,/g, ''),
     ),
 };

--- a/docs/web-scraper/code/wrapping-it-up-1.js
+++ b/docs/web-scraper/code/wrapping-it-up-1.js
@@ -18,6 +18,6 @@ return {
         $('ul.ActorHeader-stats > li:nth-of-type(3)')
             .text()
             .match(/[\d,]+/)[0]
-            .replace(',', ''),
+            .replace(/,/g, ''),
     ),
 };

--- a/docs/web-scraper/code/wrapping-it-up-2.js
+++ b/docs/web-scraper/code/wrapping-it-up-2.js
@@ -31,7 +31,7 @@ async function pageFunction(context) {
                 $('ul.ActorHeader-stats > li:nth-of-type(3)')
                     .text()
                     .match(/[\d,]+/)[0]
-                    .replace(',', ''),
+                    .replace(/,/g, ''),
             ),
         };
     }


### PR DESCRIPTION
Hopefully the last missing piece, some scrapers have large run counts that contain multiple separators (e.g. `18,765,807 times`).