### PR TITLE
chore: prefill proxy in input schema

### DIFF
--- a/cheerio-scraper/INPUT_SCHEMA.json
+++ b/cheerio-scraper/INPUT_SCHEMA.json
@@ -64,7 +64,7 @@
 			"title": "Proxy configuration",
 			"type": "object",
 			"description": "Specifies proxy servers that will be used by the scraper in order to hide its origin.<br><br>For details, see <a href='https://apify.com/apify/cheerio-scraper#proxy-configuration' target='_blank' rel='noopener'>Proxy configuration</a> in README.",
-			"prefill": { "useApifyProxy": false },
+			"prefill": { "useApifyProxy": true },
 			"default": { "useApifyProxy": false },
 			"editor": "proxy"
 		},

--- a/puppeteer-scraper/INPUT_SCHEMA.json
+++ b/puppeteer-scraper/INPUT_SCHEMA.json
@@ -73,7 +73,7 @@
       "title": "Proxy configuration",
       "type": "object",
       "description": "Choose to use no proxy, Apify Proxy, or provide custom proxy URLs.",
-      "prefill": { "useApifyProxy": false },
+      "prefill": { "useApifyProxy": true },
       "default": { "useApifyProxy": false },
       "editor": "proxy"
     },

--- a/web-scraper/INPUT_SCHEMA.json
+++ b/web-scraper/INPUT_SCHEMA.json
@@ -90,7 +90,7 @@
             "title": "Proxy configuration",
             "type": "object",
             "description": "Specifies proxy servers that will be used by the scraper in order to hide its origin.<br><br>For details, see <a href='https://apify.com/apify/web-scraper#proxy-configuration' target='_blank' rel='noopener'>Proxy configuration</a> in README.",
-            "prefill": { "useApifyProxy": false },
+            "prefill": { "useApifyProxy": true },
             "default": { "useApifyProxy": false },
             "editor": "proxy"
         },


### PR DESCRIPTION
We want users of public actors to use proxy by default. Most other actors already enforce this. Enforcing this here would be a breaking change which I don't want to do so soon after releasing v2, but we can at least mitigate by prefilling the proxy on input.