### PR TITLE
fix(web-scraper): table of contents

### DIFF
--- a/web-scraper/README.md
+++ b/web-scraper/README.md
@@ -14,9 +14,8 @@ in Apify documentation,
 and then continue with [**Scraping with Web Scraper**](https://apify.com/docs/scraping/tutorial/web-scraper),
 a tutorial which will walk you through all the steps and provide a number of examples.
 
-## Table of content
-
 <!-- toc -->
+## Table of content
 
 - [Usage](#usage)
 - [Limitations](#limitations)


### PR DESCRIPTION
We are now generating custom table of contents from the readme content and we might want to remove the one that is within `<!-- toc -->` and `<!-- tocstop -->` comment tags. We actually remove this on web as well but so far we were counting with different tags:
- `<!-- toc start -->`
-  `<!-- toc end -->`

Not sure who to align with about this

I just moved the Table of contents heading inside the comment tags so that it is removed as well.

![CleanShot 2023-04-13 at 15 50 29@2x](https://user-images.githubusercontent.com/39300846/231779844-36c47e8e-c1d5-4b31-a19f-7153e9ba152a.png)
