### PR TITLE
fix: prevent DevToolsServer port conflicts on BrowserPool relaunch

### DIFF
--- a/packages/actor-scraper/web-scraper/test/bundle.browser.test.ts
+++ b/packages/actor-scraper/web-scraper/test/bundle.browser.test.ts
@@ -1,15 +1,5 @@
 import { launchPuppeteer } from '@crawlee/puppeteer';
 import type { Browser, Page } from 'puppeteer';
-import {
-    afterAll,
-    afterEach,
-    beforeAll,
-    beforeEach,
-    describe,
-    expect,
-    it,
-    vi,
-} from 'vitest';
 
 import { createBundle } from '../src/internals/bundle.browser';
 
@@ -107,42 +97,6 @@ describe('Bundle', () => {
                 });
                 expect(millis).toBeGreaterThan(9);
             });
-        });
-    });
-
-    describe('DevToolsServer (regression)', () => {
-        it('starts only once even if preLaunchHook calls it multiple times', async () => {
-            const oldEnv = process.env;
-            process.env = { ...oldEnv };
-
-            process.env.ACTOR_WEB_SERVER_URL = 'http://127.0.0.1:4321';
-            process.env.ACTOR_WEB_SERVER_PORT = '4321';
-
-            const startMock = vi.fn(async () => {});
-            const stopMock = vi.fn(() => {});
-            const DevToolsCtorMock = vi.fn(() => ({
-                start: startMock,
-                stop: stopMock,
-            }));
-
-            vi.resetModules();
-            vi.doMock('devtools-server', () => ({ default: DevToolsCtorMock }));
-            vi.doMock('apify', () => ({ Actor: { on: vi.fn() } }));
-
-            const mod = await import('../src/internals/crawler_setup.ts');
-            const { CrawlerSetup } = mod as any;
-
-            await Promise.all(
-                Array.from({ length: 10 }, () =>
-                    // eslint-disable-next-line no-underscore-dangle
-                    CrawlerSetup._startDevToolsServerOnce(),
-                ),
-            );
-
-            expect(DevToolsCtorMock).toHaveBeenCalledTimes(1);
-            expect(startMock).toHaveBeenCalledTimes(1);
-
-            process.env = oldEnv;
         });
     });
 });

--- a/packages/actor-scraper/web-scraper/test/devtools-server.regression.test.ts
+++ b/packages/actor-scraper/web-scraper/test/devtools-server.regression.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+
+describe('DevToolsServer (regression)', () => {
+    it('starts only once even if preLaunchHook calls it multiple times', async () => {
+        const oldEnv = process.env;
+        const actorOnMock = vi.fn();
+
+        const startMock = vi.fn(async () => {});
+        const stopMock = vi.fn(() => {});
+        const DevToolsCtorMock = vi.fn(() => ({
+            start: startMock,
+            stop: stopMock,
+        }));
+
+        try {
+            process.env = { ...oldEnv };
+            process.env.ACTOR_WEB_SERVER_URL = 'http://127.0.0.1:4321';
+            process.env.ACTOR_WEB_SERVER_PORT = '4321';
+
+            vi.resetModules();
+            vi.doMock('devtools-server', () => ({ default: DevToolsCtorMock }));
+            vi.doMock('apify', () => ({ Actor: { on: actorOnMock } }));
+
+            const mod = await import(
+                new URL('../src/internals/crawler_setup.ts', import.meta.url)
+                    .href
+            );
+            const { CrawlerSetup } = mod as any;
+
+            CrawlerSetup.devToolsServerPromise = null;
+
+            const fn =
+                CrawlerSetup.getDevToolsServer ??
+                CrawlerSetup.startDevToolsServerOnce;
+
+            await Promise.all(
+                Array.from({ length: 10 }, () => fn.call(CrawlerSetup)),
+            );
+
+            expect(DevToolsCtorMock).toHaveBeenCalledTimes(1);
+            expect(startMock).toHaveBeenCalledTimes(1);
+            expect(actorOnMock).toHaveBeenCalledTimes(1);
+            expect(actorOnMock).toHaveBeenCalledWith(
+                'exit',
+                expect.any(Function),
+            );
+        } finally {
+            process.env = oldEnv;
+            vi.resetModules();
+        }
+    });
+});


### PR DESCRIPTION
Fixes a Web Scraper dev-mode issue where DevToolsServer was started from BrowserPool’s preLaunchHook on every browser launch/relaunch, causing EADDRINUSE port conflicts after browser/page crashes or pool relaunches. The PR makes DevToolsServer startup idempotent by starting it only once per actor process (reusing a cached start promise on subsequent hook calls) and registers a single Actor.on('exit') cleanup to stop the server.

Closes #208