### PR TITLE
fix: add timeout to discoveryValidSitemaps

### DIFF
--- a/packages/actor-scraper/sitemap-scraper/src/internals/crawler_setup.ts
+++ b/packages/actor-scraper/sitemap-scraper/src/internals/crawler_setup.ts
@@ -119,7 +119,7 @@ export class CrawlerSetup implements CrawlerSetupOptions {
         );
         const discovered = await Promise.race([
             discoveryPromise,
-            sleep(SITEMAP_DISCOVERY_TIMEOUT_MILLIS).then(() => null),
+            sleep(SITEMAP_DISCOVERY_TIMEOUT_MILLIS),
         ]);
         if (!discovered) {
             log.warning(
@@ -128,7 +128,10 @@ export class CrawlerSetup implements CrawlerSetupOptions {
                 )}s, continuing without sitemaps.`,
             );
         }
-        const discoveredSitemaps = new Set(discovered ?? []);
+        const discoveredSitemaps =
+            discovered && discovered.length > 0
+                ? new Set(discovered)
+                : new Set<string>();
         if (discoveredSitemaps.size === 0) {
             throw await Actor.fail(
                 'No valid sitemaps were discovered from the provided startUrls.',


### PR DESCRIPTION
discoverValidSitemaps (from Crawlee) sends network requests to robots & sitemap files without timeouts.
If any of those requests hangs before a response, the promise never resolves -> the async iterator stalls -> crawler startup is blocked.

Solution: Add a timeout for discovery (e.g., 30s)
If discovery hangs, continue without sitemaps.

The fix does the same as PR in WCC https://github.com/apify/store-website-content-crawler/pull/599

Closes #229 