### PR TITLE
fix(sitemap-extractor): retry discovery once without proxy

### DIFF
--- a/packages/actor-scraper/sitemap-scraper/src/internals/crawler_setup.ts
+++ b/packages/actor-scraper/sitemap-scraper/src/internals/crawler_setup.ts
@@ -217,7 +217,9 @@ export class CrawlerSetup {
         }
     }
 
-    private async _discoverSitemaps(startUrls: string[]) {
+    private async _discoverSitemaps(
+        startUrls: string[],
+    ): Promise<SitemapDiscoveryResult> {
         const discoveryProxyUrl = await this.proxyConfiguration?.newUrl();
         const proxyAttempt = await this._discoverSitemapsWithTimeout(
             startUrls,
@@ -234,7 +236,7 @@ export class CrawlerSetup {
             return {
                 ...proxyAttempt,
                 disableProxyForRun: false,
-            } satisfies SitemapDiscoveryResult;
+            };
         }
 
         log.warning(
@@ -249,7 +251,7 @@ export class CrawlerSetup {
                 noProxyAttempt.discovered &&
                     noProxyAttempt.discovered.length > 0,
             ),
-        } satisfies SitemapDiscoveryResult;
+        };
     }
 
     private async _initializeAsync() {


### PR DESCRIPTION
The fix adds 
1) a small fallback: discovery still runs through proxy first, and only if that attempt errors, times out, or returns no sitemaps, we retry once without proxy. If the second attempt also finds nothing, the actor fails as before.

2) If we rerun discoverValidSitemaps without proxy, discovery succeeds, but the rest of the crawl still runs through proxy. As a result, sitemap responses can come back as non-XML content (likely an anti-bot HTML page), which leads to Unencoded < parsing errors. To avoid shipping a fix that is only partially useful, decided to include handling for these follow-up proxy-related failures in the same PR.

Closes #240


