### PR TITLE
refactor: use semver range for `@apify/scraper-tools` instead of `workspace:*`

### DIFF
--- a/packages/actor-scraper/camoufox-scraper/package.json
+++ b/packages/actor-scraper/camoufox-scraper/package.json
@@ -5,7 +5,7 @@
     "description": "Crawl web pages using Apify, headless browser and Playwright with Camoufox",
     "type": "module",
     "dependencies": {
-        "@apify/scraper-tools": "workspace:*",
+        "@apify/scraper-tools": "^1.1.4",
         "@crawlee/core": "^3.14.1",
         "@crawlee/playwright": "^3.14.1",
         "@crawlee/utils": "^3.14.1",

--- a/packages/actor-scraper/cheerio-scraper/package.json
+++ b/packages/actor-scraper/cheerio-scraper/package.json
@@ -5,7 +5,7 @@
     "description": "Crawl web pages using HTTP requests and Cheerio",
     "type": "module",
     "dependencies": {
-        "@apify/scraper-tools": "workspace:*",
+        "@apify/scraper-tools": "^1.1.4",
         "@crawlee/cheerio": "^3.16.0",
         "apify": "^3.2.6"
     },

--- a/packages/actor-scraper/jsdom-scraper/package.json
+++ b/packages/actor-scraper/jsdom-scraper/package.json
@@ -5,7 +5,7 @@
     "description": "Crawl web pages using HTTP requests and JSDOM parser",
     "type": "module",
     "dependencies": {
-        "@apify/scraper-tools": "workspace:*",
+        "@apify/scraper-tools": "^1.1.4",
         "@crawlee/jsdom": "^3.14.1",
         "apify": "^3.2.6"
     },

--- a/packages/actor-scraper/playwright-scraper/package.json
+++ b/packages/actor-scraper/playwright-scraper/package.json
@@ -5,7 +5,7 @@
     "description": "Crawl web pages using Apify, headless browser and Playwright",
     "type": "module",
     "dependencies": {
-        "@apify/scraper-tools": "workspace:*",
+        "@apify/scraper-tools": "^1.1.4",
         "@crawlee/core": "^3.16.0",
         "@crawlee/playwright": "^3.16.0",
         "@crawlee/utils": "^3.16.0",

--- a/packages/actor-scraper/puppeteer-scraper/package.json
+++ b/packages/actor-scraper/puppeteer-scraper/package.json
@@ -5,7 +5,7 @@
     "description": "Crawl web pages using Apify, headless Chrome and Puppeteer",
     "type": "module",
     "dependencies": {
-        "@apify/scraper-tools": "workspace:*",
+        "@apify/scraper-tools": "^1.1.4",
         "@crawlee/puppeteer": "^3.16.0",
         "apify": "^3.2.6",
         "idcac-playwright": "^0.2.0",

--- a/packages/actor-scraper/sitemap-scraper/package.json
+++ b/packages/actor-scraper/sitemap-scraper/package.json
@@ -5,7 +5,7 @@
     "description": "Crawl web pages from a sitemap using HTTP HEAD requests",
     "type": "module",
     "dependencies": {
-        "@apify/scraper-tools": "workspace:*",
+        "@apify/scraper-tools": "^1.1.4",
         "@crawlee/core": "4.0.0-beta.43",
         "@crawlee/http": "4.0.0-beta.43",
         "@crawlee/impit-client": "4.0.0-beta.43",

--- a/packages/actor-scraper/web-scraper/package.json
+++ b/packages/actor-scraper/web-scraper/package.json
@@ -6,7 +6,7 @@
     "main": "dist/main.js",
     "type": "module",
     "dependencies": {
-        "@apify/scraper-tools": "workspace:*",
+        "@apify/scraper-tools": "^1.1.4",
         "@crawlee/puppeteer": "^3.16.0",
         "apify": "^3.2.6",
         "content-type": "^1.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,7 +120,7 @@ importers:
   packages/actor-scraper/camoufox-scraper:
     dependencies:
       '@apify/scraper-tools':
-        specifier: workspace:*
+        specifier: ^1.1.4
         version: link:../../scraper-tools
       '@crawlee/core':
         specifier: ^3.14.1
@@ -160,7 +160,7 @@ importers:
   packages/actor-scraper/cheerio-scraper:
     dependencies:
       '@apify/scraper-tools':
-        specifier: workspace:*
+        specifier: ^1.1.4
         version: link:../../scraper-tools
       '@crawlee/cheerio':
         specifier: ^3.16.0
@@ -188,7 +188,7 @@ importers:
   packages/actor-scraper/jsdom-scraper:
     dependencies:
       '@apify/scraper-tools':
-        specifier: workspace:*
+        specifier: ^1.1.4
         version: link:../../scraper-tools
       '@crawlee/jsdom':
         specifier: ^3.14.1
@@ -216,7 +216,7 @@ importers:
   packages/actor-scraper/playwright-scraper:
     dependencies:
       '@apify/scraper-tools':
-        specifier: workspace:*
+        specifier: ^1.1.4
         version: link:../../scraper-tools
       '@crawlee/core':
         specifier: ^3.16.0
@@ -253,7 +253,7 @@ importers:
   packages/actor-scraper/puppeteer-scraper:
     dependencies:
       '@apify/scraper-tools':
-        specifier: workspace:*
+        specifier: ^1.1.4
         version: link:../../scraper-tools
       '@crawlee/puppeteer':
         specifier: ^3.16.0
@@ -284,7 +284,7 @@ importers:
   packages/actor-scraper/sitemap-scraper:
     dependencies:
       '@apify/scraper-tools':
-        specifier: workspace:*
+        specifier: ^1.1.4
         version: link:../../scraper-tools
       '@crawlee/core':
         specifier: 4.0.0-beta.43
@@ -321,7 +321,7 @@ importers:
   packages/actor-scraper/web-scraper:
     dependencies:
       '@apify/scraper-tools':
-        specifier: workspace:*
+        specifier: ^1.1.4
         version: link:../../scraper-tools
       '@crawlee/puppeteer':
         specifier: ^3.16.0


### PR DESCRIPTION
## Summary

After the pnpm migration in #273, each actor's `package.json` referenced `@apify/scraper-tools` as `workspace:*`. The actors are built on Apify via their own Dockerfile (`npm install` + `npm run build`), and **npm rejects the workspace protocol in a single-package context** with `EUNSUPPORTEDPROTOCOL`. The next manual run of `release-generic-actors.yaml` would have failed for every scraper.

Reverts the dep specifier on each actor to a regular semver range (`^1.1.4`, matching the locally-published version). Because `pnpm-workspace.yaml` has `linkWorkspacePackages: true`, local development still resolves to the workspace symlink, but the Apify Docker build now sees a normal range it can install from npm.

Verified locally:
- Workspace linkage preserved (`packages/actor-scraper/web-scraper/node_modules/@apify/scraper-tools` is a symlink to `packages/scraper-tools`)
- `npm install` against the actor's `package.json` (simulating Apify's build) now succeeds — added 410 packages in 24s
- Full `pnpm ci:build` still passes