### PR TITLE
chore: drop trailingComma default from .oxfmtrc.json

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,5 +1,4 @@
 {
-    "trailingComma": "all",
     "printWidth": 120,
     "ignorePatterns": [
         "**/*.md",


### PR DESCRIPTION
## Summary

`trailingComma: "all"` is the [default](https://oxc.rs/docs/guide/usage/formatter/config-file-reference.html#trailingcomma) in oxfmt — drop it as pure noise. No formatting changes; `pnpm format:check` stays clean.

## Test plan

- [x] `pnpm format:check` passes