### PR TITLE
chore: label new issues with t-universe instead of t-tooling

### DIFF
--- a/.github/workflows/update-new-issue.yaml
+++ b/.github/workflows/update-new-issue.yaml
@@ -13,7 +13,7 @@ jobs:
             issues: write
 
         steps:
-            # Add the "t-tooling" label to all new issues
+            # Add the "t-universe" label to all new issues
             - uses: actions/github-script@v8
               with:
                   script: |
@@ -21,5 +21,5 @@ jobs:
                           issue_number: context.issue.number,
                           owner: context.repo.owner,
                           repo: context.repo.repo,
-                          labels: ["t-tooling"]
+                          labels: ["t-universe"]
                       })


### PR DESCRIPTION
## Summary
- Switches the auto-label workflow for new issues from `t-tooling` to `t-universe` to reflect the team rename.

## Test plan
- [ ] Open a new issue and verify the `t-universe` label is applied automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)