### PR TITLE
feat(sitemap): add lastmod to extracted page output

### DIFF
--- a/packages/actor-scraper/sitemap-scraper/.actor/actor.json
+++ b/packages/actor-scraper/sitemap-scraper/.actor/actor.json
@@ -21,6 +21,11 @@
                     "title": "Status code",
                     "description": "HTTP status code from the HEAD request."
                 },
+                "lastmod": {
+                    "type": ["string", "null"],
+                    "title": "Last modified",
+                    "description": "Last-modification time (ISO 8601) from the sitemap <lastmod> tag, falling back to the page's Last-Modified header. Null when neither is available."
+                },
                 "#error": {
                     "type": "boolean",
                     "title": "Error flag",
@@ -32,7 +37,29 @@
                     "description": "Request debug info (id, retry count, errors, etc.)."
                 }
             },
-            "views": {}
+            "views": {
+                "overview": {
+                    "title": "Overview",
+                    "transformation": {
+                        "fields": ["url", "status", "lastmod"]
+                    },
+                    "display": {
+                        "component": "table",
+                        "properties": {
+                            "url": {
+                                "label": "URL",
+                                "format": "link"
+                            },
+                            "status": {
+                                "label": "Status code"
+                            },
+                            "lastmod": {
+                                "label": "Last modified"
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/packages/actor-scraper/sitemap-scraper/.actor/output_schema.json
+++ b/packages/actor-scraper/sitemap-scraper/.actor/output_schema.json
@@ -6,7 +6,7 @@
         "results": {
             "type": "string",
             "title": "Results",
-            "description": "Dataset items with discovered URLs and crawl status.",
+            "description": "Dataset items with discovered URLs, crawl status, and last-modification info.",
             "template": "{{links.apiDefaultDatasetUrl}}/items"
         }
     }

--- a/packages/actor-scraper/sitemap-scraper/.actor/output_schema.json
+++ b/packages/actor-scraper/sitemap-scraper/.actor/output_schema.json
@@ -6,7 +6,7 @@
         "results": {
             "type": "string",
             "title": "Results",
-            "description": "Dataset items with discovered URLs, crawl status, and last-modification info.",
+            "description": "Dataset items with discovered URLs, crawl status, and date-time of last modification.",
             "template": "{{links.apiDefaultDatasetUrl}}/items"
         }
     }

--- a/packages/actor-scraper/sitemap-scraper/README.md
+++ b/packages/actor-scraper/sitemap-scraper/README.md
@@ -7,7 +7,7 @@ This Actor is designed to bridge the gap between discovery and crawling. By trav
 - **Recursive Sitemap Discovery:** Automatically detects and traverses nested sitemaps (sitemap indexes).
 - **Efficiency:** Uses HTTP HEAD requests for URL validation, which are significantly faster and consume less bandwidth than full GET requests.
 - **Proxy Support:** Integrated with Apify Proxy to prevent rate limiting or blocking during the discovery phase.
-- **Detailed Output:** Provides the final URL, the corresponding HTTP status code, and the page's last-modification time.
+- **Detailed Output:** Provides the final URL, the corresponding HTTP status code, and the date-time of the page's last modification.
 
 ## How it Works
 

--- a/packages/actor-scraper/sitemap-scraper/README.md
+++ b/packages/actor-scraper/sitemap-scraper/README.md
@@ -7,7 +7,7 @@ This Actor is designed to bridge the gap between discovery and crawling. By trav
 - **Recursive Sitemap Discovery:** Automatically detects and traverses nested sitemaps (sitemap indexes).
 - **Efficiency:** Uses HTTP HEAD requests for URL validation, which are significantly faster and consume less bandwidth than full GET requests.
 - **Proxy Support:** Integrated with Apify Proxy to prevent rate limiting or blocking during the discovery phase.
-- **Detailed Output:** Provides the final URL and the corresponding HTTP status code.
+- **Detailed Output:** Provides the final URL, the corresponding HTTP status code, and the page's last-modification time.
 
 ## How it Works
 
@@ -15,6 +15,25 @@ This Actor is designed to bridge the gap between discovery and crawling. By trav
 2.  **Extraction:** The Actor parses the XML, extracting both page URLs and links to further sitemaps.
 3.  **Validation:** For every page URL found, the Actor performs a status check.
 4.  **Deduplication:** The crawler uses unique keys to ensure that even if a URL appears in multiple sitemaps, it is only checked once.
+
+## Output
+
+For each page URL, the Actor outputs:
+
+| Field    |                                       Description                                       |
+| :------- | :-------------------------------------------------------------------------------------: |
+| `url`    |                                The page URL from the sitemap.                           |
+| `status` |                       The HTTP status code returned by the HEAD request.                |
+| `lastmod` | Best-effort last-modification time (ISO 8601). See the note below.                      |
+
+### A note on last-modification data
+
+The `lastmod` field is a single best-effort timestamp derived from two sources, in this order of preference:
+
+1.  The `<lastmod>` tag declared for the URL in the sitemap.
+2.  The `Last-Modified` HTTP header returned by the page (used only when the sitemap has no `<lastmod>`).
+
+**We cannot guarantee that this information is available.** Both sources are optional: many sitemaps omit `<lastmod>` entirely, and a lot of servers don't send a `Last-Modified` header (this is especially common for dynamically generated pages). When neither source provides a value, `lastmod` is `null`. Even when present, the value is self-reported by the site and may not reflect the true last-modification time of the content.
 
 ## Usage
 

--- a/packages/actor-scraper/sitemap-scraper/src/internals/crawler_setup.ts
+++ b/packages/actor-scraper/sitemap-scraper/src/internals/crawler_setup.ts
@@ -465,7 +465,16 @@ export class CrawlerSetup {
 
     private _getLastModifiedHeader(response: any): string | null {
         const headers = response?.headers;
-        if (!headers || typeof headers !== 'object') {
+        if (!headers) {
+            return null;
+        }
+
+        if (typeof headers.get === 'function') {
+            const headerValue = headers.get('last-modified');
+            return typeof headerValue === 'string' ? headerValue : null;
+        }
+
+        if (typeof headers !== 'object') {
             return null;
         }
 

--- a/packages/actor-scraper/sitemap-scraper/src/internals/crawler_setup.ts
+++ b/packages/actor-scraper/sitemap-scraper/src/internals/crawler_setup.ts
@@ -28,6 +28,12 @@ const { META_KEY } = scraperToolsConstants;
 type RequestMetadata = {
     parentRequestId?: string;
     depth: number;
+    sitemapLastmod?: string;
+};
+
+type SitemapPageEntry = {
+    url: string;
+    lastmod?: string;
 };
 
 const { SESSION_MAX_USAGE_COUNTS } = scraperToolsConstants;
@@ -378,14 +384,14 @@ export class CrawlerSetup {
             },
         );
         const nestedSitemaps: string[] = [];
-        const urls: string[] = [];
+        const pages: SitemapPageEntry[] = [];
         let scrapedAnyPageUrls = false;
         let scrapedAnySitemapUrls = false;
 
         const flushUrls = async () => {
-            if (urls.length === 0) return;
-            await this._enqueuePageRequests(urls, crawlingContext);
-            urls.length = 0;
+            if (pages.length === 0) return;
+            await this._enqueuePageRequests(pages, crawlingContext);
+            pages.length = 0;
         };
 
         const flushSitemaps = async () => {
@@ -407,7 +413,7 @@ export class CrawlerSetup {
                     url: item.loc,
                 });
 
-                urls.push(item.loc);
+                pages.push({ url: item.loc, lastmod: this._normalizeToIsoString(item.lastmod) ?? undefined });
                 scrapedAnyPageUrls = true;
             }
 
@@ -415,7 +421,7 @@ export class CrawlerSetup {
                 await flushSitemaps();
             }
 
-            if (urls.length >= REQUESTS_BATCH_SIZE) {
+            if (pages.length >= REQUESTS_BATCH_SIZE) {
                 await flushUrls();
             }
         }
@@ -443,13 +449,42 @@ export class CrawlerSetup {
         tools.ensureMetaData(request as any);
 
         const status = (response as any)?.status ?? (response as any)?.statusCode;
+
+        const sitemapLastmod = (request.userData?.[META_KEY] as RequestMetadata | undefined)?.sitemapLastmod ?? null;
+        const lastModifiedHeader = this._getLastModifiedHeader(response);
+
         const result = {
             url: request.url,
             status,
+            lastmod: sitemapLastmod ?? this._normalizeToIsoString(lastModifiedHeader),
         };
 
         // Save the `pageFunction`s result to the default dataset.
         await this._handleResult(request, response as any, result);
+    }
+
+    private _getLastModifiedHeader(response: any): string | null {
+        const headers = response?.headers;
+        if (!headers || typeof headers !== 'object') {
+            return null;
+        }
+
+        for (const [key, value] of Object.entries(headers)) {
+            if (key.toLowerCase() !== 'last-modified') continue;
+            const headerValue = Array.isArray(value) ? value[0] : value;
+            return typeof headerValue === 'string' ? headerValue : null;
+        }
+
+        return null;
+    }
+
+    private _normalizeToIsoString(value: Date | string | null | undefined): string | null {
+        if (!value) {
+            return null;
+        }
+
+        const date = value instanceof Date ? value : new Date(value);
+        return Number.isNaN(date.getTime()) ? null : date.toISOString();
     }
 
     private async _handleResult(request: Request, response?: any, pageFunctionResult?: Dictionary, isError?: boolean) {
@@ -545,20 +580,32 @@ export class CrawlerSetup {
         return body.length >= 2 && body[0] === 0x1f && body[1] === 0x8b;
     }
 
-    private async _enqueuePageRequests(urls: string[], { request, enqueueLinks }: HttpCrawlingContext) {
+    private async _enqueuePageRequests(pages: SitemapPageEntry[], { request, enqueueLinks }: HttpCrawlingContext) {
         const currentDepth = (request.userData![META_KEY] as RequestMetadata).depth;
 
         // NOTE: depth check when enqueueing pages is not needed, since the one
         // for sitemaps will do the job
 
+        // Key by `new URL(url).href` — the normalized form enqueueLinks passes to our transform.
+        const lastmodByUrl = new Map<string, string>();
+        for (const { url, lastmod } of pages) {
+            if (!lastmod) continue;
+            try {
+                lastmodByUrl.set(new URL(url).href, lastmod);
+            } catch {
+                // ignore invalid URLs (enqueueLinks drops them too)
+            }
+        }
+
         await enqueueLinks({
-            urls,
+            urls: pages.map((page) => page.url),
             label: this.PAGE_LABEL,
             transformRequestFunction: (requestOptions) => {
                 requestOptions.userData ??= {};
                 requestOptions.userData[META_KEY] = {
                     parentRequestId: request.id || request.uniqueKey,
                     depth: currentDepth + 1,
+                    sitemapLastmod: lastmodByUrl.get(requestOptions.url),
                 };
 
                 requestOptions.useExtendedUniqueKey = true;

--- a/packages/actor-scraper/sitemap-scraper/test/crawler-setup-lastmod.test.ts
+++ b/packages/actor-scraper/sitemap-scraper/test/crawler-setup-lastmod.test.ts
@@ -32,7 +32,7 @@ const createInput = (overrides: Partial<Input> = {}): Input => ({
     ...overrides,
 });
 
-const createPageContext = (userData: Record<string, unknown>, headers: Record<string, string> = {}): any => ({
+const createPageContext = (userData: Record<string, unknown>, headers: Headers | Record<string, string> = {}): any => ({
     request: {
         url: 'https://example.com/page',
         userData,
@@ -79,11 +79,26 @@ describe('CrawlerSetup lastmod handling', () => {
         const handleResult = vi.spyOn(setup as any, '_handleResult').mockResolvedValue(undefined);
 
         await (setup as any)._handlePageRequest(
-            createPageContext({ [META_KEY]: { depth: 1 } }, { 'Last-Modified': 'Wed, 21 Oct 2015 07:28:00 GMT' }),
+            createPageContext({ [META_KEY]: { depth: 1 } }, { 'last-modified': 'Wed, 21 Oct 2015 07:28:00 GMT' }),
         );
 
         const result = handleResult.mock.calls[0][2];
         expect(result).toMatchObject({ lastmod: '2015-10-21T07:28:00.000Z' });
+    });
+
+    it('reads the Last-Modified header from Web Headers returned by the HTTP client', async () => {
+        const setup = new CrawlerSetup(createInput());
+        const handleResult = vi.spyOn(setup as any, '_handleResult').mockResolvedValue(undefined);
+
+        await (setup as any)._handlePageRequest(
+            createPageContext(
+                { [META_KEY]: { depth: 1 } },
+                new Headers({ 'last-modified': 'Fri, 26 Jun 2026 11:10:48 GMT' }),
+            ),
+        );
+
+        const result = handleResult.mock.calls[0][2];
+        expect(result).toMatchObject({ lastmod: '2026-06-26T11:10:48.000Z' });
     });
 
     it('reports null lastmod when neither source provides last-modification data', async () => {

--- a/packages/actor-scraper/sitemap-scraper/test/crawler-setup-lastmod.test.ts
+++ b/packages/actor-scraper/sitemap-scraper/test/crawler-setup-lastmod.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { constants } from '@apify/scraper-tools';
+
+import { type Input, ProxyRotation } from '../src/internals/consts.js';
+import { CrawlerSetup } from '../src/internals/crawler_setup.js';
+
+const { META_KEY } = constants;
+
+vi.mock('apify', () => ({
+    Actor: {
+        isAtHome: () => true,
+        getEnv: () => ({}),
+        createProxyConfiguration: async () => ({
+            newUrl: async () => undefined,
+        }),
+        fail: async (message: string) => new Error(message),
+    },
+}));
+
+const createInput = (overrides: Partial<Input> = {}): Input => ({
+    startUrls: [{ url: 'https://example.com' }],
+    keepUrlFragments: false,
+    respectRobotsTxtFile: true,
+    pageFunction: '() => ({})',
+    proxyConfiguration: { useApifyProxy: false },
+    proxyRotation: ProxyRotation.Recommended,
+    maxRequestRetries: 3,
+    maxCrawlingDepth: 0,
+    debugLog: false,
+    customData: {},
+    ...overrides,
+});
+
+const createPageContext = (userData: Record<string, unknown>, headers: Record<string, string> = {}): any => ({
+    request: {
+        url: 'https://example.com/page',
+        userData,
+    },
+    response: {
+        statusCode: 200,
+        headers,
+    },
+});
+
+describe('CrawlerSetup lastmod handling', () => {
+    let initSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        initSpy = vi.spyOn(CrawlerSetup.prototype as any, '_initializeAsync').mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+        initSpy.mockRestore();
+    });
+
+    it('prefers the sitemap <lastmod> over the Last-Modified header', async () => {
+        const setup = new CrawlerSetup(createInput());
+        const handleResult = vi.spyOn(setup as any, '_handleResult').mockResolvedValue(undefined);
+
+        await (setup as any)._handlePageRequest(
+            createPageContext(
+                { [META_KEY]: { depth: 1, sitemapLastmod: '2024-01-01T00:00:00.000Z' } },
+                { 'last-modified': 'Wed, 21 Oct 2015 07:28:00 GMT' },
+            ),
+        );
+
+        const result = handleResult.mock.calls[0][2];
+        expect(result).toMatchObject({
+            url: 'https://example.com/page',
+            status: 200,
+            lastmod: '2024-01-01T00:00:00.000Z',
+        });
+        expect(result).not.toHaveProperty('lastModifiedHeader');
+    });
+
+    it('falls back to the Last-Modified header, normalized to ISO 8601, when the sitemap has none', async () => {
+        const setup = new CrawlerSetup(createInput());
+        const handleResult = vi.spyOn(setup as any, '_handleResult').mockResolvedValue(undefined);
+
+        await (setup as any)._handlePageRequest(
+            createPageContext({ [META_KEY]: { depth: 1 } }, { 'Last-Modified': 'Wed, 21 Oct 2015 07:28:00 GMT' }),
+        );
+
+        const result = handleResult.mock.calls[0][2];
+        expect(result).toMatchObject({ lastmod: '2015-10-21T07:28:00.000Z' });
+    });
+
+    it('reports null lastmod when neither source provides last-modification data', async () => {
+        const setup = new CrawlerSetup(createInput());
+        const handleResult = vi.spyOn(setup as any, '_handleResult').mockResolvedValue(undefined);
+
+        await (setup as any)._handlePageRequest(createPageContext({ [META_KEY]: { depth: 1 } }, {}));
+
+        const result = handleResult.mock.calls[0][2];
+        expect(result).toMatchObject({ lastmod: null });
+    });
+
+    it('carries the sitemap lastmod onto enqueued page requests', async () => {
+        const setup = new CrawlerSetup(createInput());
+
+        let transform: ((opts: any) => any) | undefined;
+        const enqueueLinks = vi.fn(async ({ transformRequestFunction }: any) => {
+            transform = transformRequestFunction;
+        });
+
+        // Second URL is a bare root, normalized to `https://example.com/` by enqueueLinks.
+        const pages = [
+            { url: 'https://example.com/a', lastmod: '2024-05-05T00:00:00.000Z' },
+            { url: 'https://example.com', lastmod: '2024-06-06T00:00:00.000Z' },
+            { url: 'https://example.com/c' },
+        ];
+
+        await (setup as any)._enqueuePageRequests(pages, {
+            request: { id: 'parent', uniqueKey: 'parent', userData: { [META_KEY]: { depth: 0 } } },
+            enqueueLinks,
+        });
+
+        expect(enqueueLinks).toHaveBeenCalledWith(
+            expect.objectContaining({
+                urls: ['https://example.com/a', 'https://example.com', 'https://example.com/c'],
+            }),
+        );
+
+        const withLastmod = transform!({ url: 'https://example.com/a' });
+        expect(withLastmod.userData[META_KEY].sitemapLastmod).toBe('2024-05-05T00:00:00.000Z');
+        expect(withLastmod.method).toBe('HEAD');
+
+        const normalizedRoot = transform!({ url: 'https://example.com/' });
+        expect(normalizedRoot.userData[META_KEY].sitemapLastmod).toBe('2024-06-06T00:00:00.000Z');
+
+        const withoutLastmod = transform!({ url: 'https://example.com/c' });
+        expect(withoutLastmod.userData[META_KEY].sitemapLastmod).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Each page in the Sitemap Extractor output now carries a lastmod field with the page's last-modification time.

The lastmod is taken from two sources in order of preference:

The <lastmod> tag declared for the URL in the sitemap.
The Last-Modified response header, used only when the sitemap has no <lastmod>.
If neither is present, lastmod is null.

Output example
```
{
  "url": "https://example.com/page",
  "status": 200,
  "lastmod": "2024-01-01T00:00:00.000Z"
}
```

Closes https://github.com/apify/actor-scraper/issues/281