### PR TITLE
chore(deps): update Apify JS SDK to 3.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
         "@types/semver": "^7.5.8",
         "@types/tough-cookie": "^4.0.5",
         "@types/ws": "^8.5.12",
-        "apify": "^3.5.3",
+        "apify": "^3.7.1",
         "apify-client": "^2.17.0",
         "commitlint": "^20.0.0",
         "crawlee": "^3.16.0",

--- a/packages/actor-scraper/camoufox-scraper/package.json
+++ b/packages/actor-scraper/camoufox-scraper/package.json
@@ -9,7 +9,7 @@
         "@crawlee/core": "^3.14.1",
         "@crawlee/playwright": "^3.14.1",
         "@crawlee/utils": "^3.14.1",
-        "apify": "^3.2.6",
+        "apify": "^3.7.1",
         "camoufox-js": "0.11.1",
         "idcac-playwright": "^0.2.0",
         "playwright": "1.59.1",

--- a/packages/actor-scraper/cheerio-scraper/package.json
+++ b/packages/actor-scraper/cheerio-scraper/package.json
@@ -7,7 +7,7 @@
     "dependencies": {
         "@apify/scraper-tools": "^1.1.4",
         "@crawlee/cheerio": "^3.16.0",
-        "apify": "^3.2.6"
+        "apify": "^3.7.1"
     },
     "devDependencies": {
         "@apify/tsconfig": "^0.1.0",

--- a/packages/actor-scraper/jsdom-scraper/package.json
+++ b/packages/actor-scraper/jsdom-scraper/package.json
@@ -7,7 +7,7 @@
     "dependencies": {
         "@apify/scraper-tools": "^1.1.4",
         "@crawlee/jsdom": "^3.14.1",
-        "apify": "^3.2.6"
+        "apify": "^3.7.1"
     },
     "devDependencies": {
         "@apify/tsconfig": "^0.1.0",

--- a/packages/actor-scraper/playwright-scraper/package.json
+++ b/packages/actor-scraper/playwright-scraper/package.json
@@ -9,7 +9,7 @@
         "@crawlee/core": "^3.16.0",
         "@crawlee/playwright": "^3.16.0",
         "@crawlee/utils": "^3.16.0",
-        "apify": "^3.2.6",
+        "apify": "^3.7.1",
         "idcac-playwright": "^0.2.0",
         "playwright": "1.61.0"
     },

--- a/packages/actor-scraper/puppeteer-scraper/package.json
+++ b/packages/actor-scraper/puppeteer-scraper/package.json
@@ -7,7 +7,7 @@
     "dependencies": {
         "@apify/scraper-tools": "^1.1.4",
         "@crawlee/puppeteer": "^3.16.0",
-        "apify": "^3.2.6",
+        "apify": "^3.7.1",
         "idcac-playwright": "^0.2.0",
         "puppeteer": "25.2.0"
     },

--- a/packages/actor-scraper/web-scraper/package.json
+++ b/packages/actor-scraper/web-scraper/package.json
@@ -8,7 +8,7 @@
     "dependencies": {
         "@apify/scraper-tools": "^1.1.4",
         "@crawlee/puppeteer": "^3.16.0",
-        "apify": "^3.2.6",
+        "apify": "^3.7.1",
         "content-type": "^1.0.5",
         "devtools-server": "^0.0.2",
         "idcac-playwright": "^0.2.0",

--- a/packages/scraper-tools/package.json
+++ b/packages/scraper-tools/package.json
@@ -45,7 +45,7 @@
         "@crawlee/core": "^3.8.2",
         "@crawlee/types": "^3.8.2",
         "@crawlee/utils": "^3.8.2",
-        "apify": "^3.1.8"
+        "apify": "^3.7.1"
     },
     "peerDependencies": {
         "@crawlee/browser-pool": "^3.8.2 || ^4.0.0-beta.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,8 +56,8 @@ importers:
         specifier: ^8.5.12
         version: 8.18.1
       apify:
-        specifier: ^3.5.3
-        version: 3.7.0
+        specifier: ^3.7.1
+        version: 3.7.2
       apify-client:
         specifier: ^2.17.0
         version: 2.22.3
@@ -134,8 +134,8 @@ importers:
         specifier: ^3.14.1
         version: 3.16.0
       apify:
-        specifier: ^3.2.6
-        version: 3.7.0
+        specifier: ^3.7.1
+        version: 3.7.2
       camoufox-js:
         specifier: 0.11.1
         version: 0.11.1(playwright-core@1.59.1)
@@ -171,8 +171,8 @@ importers:
         specifier: ^3.16.0
         version: 3.16.0
       apify:
-        specifier: ^3.2.6
-        version: 3.7.0
+        specifier: ^3.7.1
+        version: 3.7.2
       cheerio:
         specifier: ^1.0.0-rc.12
         version: 1.2.0
@@ -199,8 +199,8 @@ importers:
         specifier: ^3.14.1
         version: 3.16.0
       apify:
-        specifier: ^3.2.6
-        version: 3.7.0
+        specifier: ^3.7.1
+        version: 3.7.2
       jsdom:
         specifier: ^29.0.0
         version: 29.0.2
@@ -233,8 +233,8 @@ importers:
         specifier: ^3.16.0
         version: 3.16.0
       apify:
-        specifier: ^3.2.6
-        version: 3.7.0
+        specifier: ^3.7.1
+        version: 3.7.2
       idcac-playwright:
         specifier: ^0.2.0
         version: 0.2.0
@@ -264,8 +264,8 @@ importers:
         specifier: ^3.16.0
         version: 3.16.0(idcac-playwright@0.2.0)(playwright@1.61.1)(puppeteer@25.2.0)
       apify:
-        specifier: ^3.2.6
-        version: 3.7.0
+        specifier: ^3.7.1
+        version: 3.7.2
       idcac-playwright:
         specifier: ^0.2.0
         version: 0.2.0
@@ -332,8 +332,8 @@ importers:
         specifier: ^3.16.0
         version: 3.16.0(idcac-playwright@0.2.0)(playwright@1.61.1)(puppeteer@25.2.0)
       apify:
-        specifier: ^3.2.6
-        version: 3.7.0
+        specifier: ^3.7.1
+        version: 3.7.2
       content-type:
         specifier: ^1.0.5
         version: 1.0.5
@@ -391,8 +391,8 @@ importers:
         specifier: ^3.8.2
         version: 3.16.0
       apify:
-        specifier: ^3.1.8
-        version: 3.7.0
+        specifier: ^3.7.1
+        version: 3.7.2
 
 packages:
 
@@ -2033,8 +2033,8 @@ packages:
   apify-client@2.22.3:
     resolution: {integrity: sha512-i09jamE2H7A/wasjOPAUs5NJkhs8m9YqOwennD2ALe2gTskPOpaUJ/QLlP8Flctm/etYFZSrJByA/uO27Fw2/A==}
 
-  apify@3.7.0:
-    resolution: {integrity: sha512-2WeMeI6BIH2ql5dtnsreKcWxE+OGqsj9LKEe1c0b7kaQpqlEHXN63OqPfDmX1EFjuGo5Z1I3uVYBx3BTQZ9+Ag==}
+  apify@3.7.2:
+    resolution: {integrity: sha512-I4R5Qd1X11vk5/1U0CxKSsMhNwER/3MntePEQb9Pbtf942OhQLh5IURrJZufqtpimkqRy44SlQMU6UhPdoFXhA==}
     engines: {node: '>=16.0.0'}
 
   apify@4.0.0-beta.12:
@@ -7098,7 +7098,7 @@ snapshots:
       - debug
       - supports-color
 
-  apify@3.7.0:
+  apify@3.7.2:
     dependencies:
       '@apify/consts': 2.52.0
       '@apify/input_secrets': 1.2.27
@@ -7113,7 +7113,7 @@ snapshots:
       ow: 0.28.2
       semver: 7.7.4
       tslib: 2.8.1
-      ws: 8.20.0
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - debug


### PR DESCRIPTION
Bump `apify` to ^3.7.1 across the v3 scrapers (web, cheerio, jsdom, playwright, puppeteer, camoufox); the lockfile resolves to 3.7.2. 
Also bump the root and @apify/scraper-tools dev dependency to the same floor so the lockfile no longer carries a stray apify 3.7.0. 
Closes #282
