### PR TITLE
feat(web-scraper): support limited permissions for named storage inputs

### DIFF
--- a/packages/actor-scraper/web-scraper/INPUT_SCHEMA.json
+++ b/packages/actor-scraper/web-scraper/INPUT_SCHEMA.json
@@ -297,19 +297,25 @@
             "title": "Dataset name",
             "type": "string",
             "description": "Name or ID of the dataset that will be used for storing results. If left empty, the default dataset of the run will be used.",
-            "editor": "textfield"
+            "editor": "textfield",
+            "resourceType": "dataset",
+            "resourcePermissions": ["READ", "WRITE"]
         },
         "keyValueStoreName": {
             "title": "Key-value store name",
             "type": "string",
             "description": "Name or ID of the key-value store that will be used for storing records. If left empty, the default key-value store of the run will be used.",
-            "editor": "textfield"
+            "editor": "textfield",
+            "resourceType": "keyValueStore",
+            "resourcePermissions": ["READ", "WRITE"]
         },
         "requestQueueName": {
             "title": "Request queue name",
             "type": "string",
             "description": "Name of the request queue that will be used for storing requests. If left empty, the default request queue of the run will be used.",
-            "editor": "textfield"
+            "editor": "textfield",
+            "resourceType": "requestQueue",
+            "resourcePermissions": ["READ", "WRITE"]
         }
     },
     "required": ["startUrls", "pageFunction", "proxyConfiguration"]


### PR DESCRIPTION
As discussed [here](https://apify.slack.com/archives/C0AH85U4614/p1783056366704589) we want to run web-scraper under **limited permissions**.

To enable it, we annotate `datasetName` / `keyValueStoreName` / `requestQueueName` as storage resources (relies on [apify-core #23142](https://github.com/apify/apify-core/pull/23142)). 