### PR TITLE
chore: mark initialCookies as secret in generic scrapers

### DIFF
--- a/packages/actor-scraper/cheerio-scraper/INPUT_SCHEMA.json
+++ b/packages/actor-scraper/cheerio-scraper/INPUT_SCHEMA.json
@@ -109,7 +109,8 @@
             "description": "A JSON array with cookies that will be send with every HTTP request made by the Cheerio Scraper, in the format accepted by the <a href='https://www.npmjs.com/package/tough-cookie' target='_blank' rel='noopener noreferrer'>tough-cookie</a> NPM package. This option is useful for transferring a logged-in session from an external web browser. For details how to do this, read this <a href='https://help.apify.com/en/articles/1444249-log-in-to-website-by-transferring-cookies-from-web-browser-legacy' target='_blank' rel='noopener'>help article</a>.",
             "default": [],
             "prefill": [],
-            "editor": "json"
+            "editor": "json",
+            "isSecret": true
         },
         "additionalMimeTypes": {
             "title": "Additional MIME types",

--- a/packages/actor-scraper/playwright-scraper/INPUT_SCHEMA.json
+++ b/packages/actor-scraper/playwright-scraper/INPUT_SCHEMA.json
@@ -108,7 +108,8 @@
             "description": "The provided cookies will be pre-set to all pages the scraper opens.",
             "default": [],
             "prefill": [],
-            "editor": "json"
+            "editor": "json",
+            "isSecret": true
         },
         "launcher": {
             "sectionCaption": "Browser configuration",

--- a/packages/actor-scraper/puppeteer-scraper/INPUT_SCHEMA.json
+++ b/packages/actor-scraper/puppeteer-scraper/INPUT_SCHEMA.json
@@ -114,7 +114,8 @@
             "description": "The provided cookies will be pre-set to all pages the scraper opens.",
             "default": [],
             "prefill": [],
-            "editor": "json"
+            "editor": "json",
+            "isSecret": true
         },
         "useChrome": {
             "title": "Use Chrome",

--- a/packages/actor-scraper/web-scraper/INPUT_SCHEMA.json
+++ b/packages/actor-scraper/web-scraper/INPUT_SCHEMA.json
@@ -124,7 +124,8 @@
             "description": "A JSON array with cookies that will be set to every Chrome browser tab opened before loading the page, in the format accepted by Puppeteer's <a href='https://pptr.dev/api/puppeteer.cookie' target='_blank' rel='noopener'><code>Page.setCookie()</code></a> function. This option is useful for transferring a logged-in session from an external web browser.",
             "default": [],
             "prefill": [],
-            "editor": "json"
+            "editor": "json",
+            "isSecret": true
         },
         "useChrome": {
             "title": "Use Chrome",


### PR DESCRIPTION
Marks the `initialCookies` input field as a secret (`isSecret: true`) in Web, Cheerio, Playwright and Puppeteer scrapers, matching WCC behavior.

Closes #298