### PR TITLE
fix: remove default from secret initialCookies input

### DIFF
--- a/packages/actor-scraper/cheerio-scraper/INPUT_SCHEMA.json
+++ b/packages/actor-scraper/cheerio-scraper/INPUT_SCHEMA.json
@@ -107,7 +107,6 @@
             "title": "Initial cookies",
             "type": "array",
             "description": "A JSON array with cookies that will be send with every HTTP request made by the Cheerio Scraper, in the format accepted by the <a href='https://www.npmjs.com/package/tough-cookie' target='_blank' rel='noopener noreferrer'>tough-cookie</a> NPM package. This option is useful for transferring a logged-in session from an external web browser. For details how to do this, read this <a href='https://help.apify.com/en/articles/1444249-log-in-to-website-by-transferring-cookies-from-web-browser-legacy' target='_blank' rel='noopener'>help article</a>.",
-            "default": [],
             "prefill": [],
             "editor": "json",
             "isSecret": true

--- a/packages/actor-scraper/cheerio-scraper/src/internals/crawler_setup.ts
+++ b/packages/actor-scraper/cheerio-scraper/src/internals/crawler_setup.ts
@@ -86,7 +86,7 @@ export class CrawlerSetup implements CrawlerSetupOptions {
             }
         });
 
-        this.input.initialCookies.forEach((cookie) => {
+        this.input.initialCookies?.forEach((cookie) => {
             if (!tools.isPlainObject(cookie)) {
                 throw new Error('The initialCookies Array must only contain Objects.');
             }

--- a/packages/actor-scraper/playwright-scraper/INPUT_SCHEMA.json
+++ b/packages/actor-scraper/playwright-scraper/INPUT_SCHEMA.json
@@ -106,7 +106,6 @@
             "title": "Initial cookies",
             "type": "array",
             "description": "The provided cookies will be pre-set to all pages the scraper opens.",
-            "default": [],
             "prefill": [],
             "editor": "json",
             "isSecret": true

--- a/packages/actor-scraper/playwright-scraper/src/internals/crawler_setup.ts
+++ b/packages/actor-scraper/playwright-scraper/src/internals/crawler_setup.ts
@@ -93,7 +93,7 @@ export class CrawlerSetup implements CrawlerSetupOptions {
             throw new Error('useChrome option could only be used with Chromium browser selected.');
         }
 
-        this.input.initialCookies.forEach((cookie) => {
+        this.input.initialCookies?.forEach((cookie) => {
             if (!tools.isPlainObject(cookie)) {
                 throw new Error('The initialCookies Array must only contain Objects.');
             }

--- a/packages/actor-scraper/puppeteer-scraper/INPUT_SCHEMA.json
+++ b/packages/actor-scraper/puppeteer-scraper/INPUT_SCHEMA.json
@@ -112,7 +112,6 @@
             "title": "Initial cookies",
             "type": "array",
             "description": "The provided cookies will be pre-set to all pages the scraper opens.",
-            "default": [],
             "prefill": [],
             "editor": "json",
             "isSecret": true

--- a/packages/actor-scraper/puppeteer-scraper/src/internals/crawler_setup.ts
+++ b/packages/actor-scraper/puppeteer-scraper/src/internals/crawler_setup.ts
@@ -88,7 +88,7 @@ export class CrawlerSetup implements CrawlerSetupOptions {
             }
         });
 
-        this.input.initialCookies.forEach((cookie) => {
+        this.input.initialCookies?.forEach((cookie) => {
             if (!tools.isPlainObject(cookie)) {
                 throw new Error('The initialCookies Array must only contain Objects.');
             }

--- a/packages/actor-scraper/web-scraper/INPUT_SCHEMA.json
+++ b/packages/actor-scraper/web-scraper/INPUT_SCHEMA.json
@@ -122,7 +122,6 @@
             "title": "Initial cookies",
             "type": "array",
             "description": "A JSON array with cookies that will be set to every Chrome browser tab opened before loading the page, in the format accepted by Puppeteer's <a href='https://pptr.dev/api/puppeteer.cookie' target='_blank' rel='noopener'><code>Page.setCookie()</code></a> function. This option is useful for transferring a logged-in session from an external web browser.",
-            "default": [],
             "prefill": [],
             "editor": "json",
             "isSecret": true

--- a/packages/actor-scraper/web-scraper/src/internals/crawler_setup.ts
+++ b/packages/actor-scraper/web-scraper/src/internals/crawler_setup.ts
@@ -123,7 +123,7 @@ export class CrawlerSetup implements CrawlerSetupOptions {
             }
         });
 
-        this.input.initialCookies.forEach((cookie) => {
+        this.input.initialCookies?.forEach((cookie) => {
             if (!tools.isPlainObject(cookie)) {
                 throw new Error('The initialCookies Array must only contain Objects.');
             }


### PR DESCRIPTION
#319 marked `initialCookies` as `isSecret`, but the field kept its `default: []`. Secret inputs can't define `default`, so the input schema no longer validates and builds fail. Dropped `default` in cheerio, playwright, puppeteer and web scrapers.

packages/actor-scraper/puppeteer-scraper

https://console.apify.com/admin/users/ZscMwFR5H7eCtWtyh/actors/YJCnS9qogi9XxDgLB/builds/0.0.61#log