### PR TITLE
feat(sitemap-scraper): add option to list sitemap URLs only

### DIFF
--- a/packages/actor-scraper/sitemap-scraper/INPUT_SCHEMA.json
+++ b/packages/actor-scraper/sitemap-scraper/INPUT_SCHEMA.json
@@ -15,6 +15,13 @@
             ],
             "editor": "requestListSources"
         },
+        "skipStatusCheck": {
+            "title": "List sitemap URLs only (skip status check)",
+            "type": "boolean",
+            "description": "By default, the Actor sends a HEAD request to every page found in the sitemaps and outputs its HTTP status code. Enable this option to skip those requests entirely and simply output the list of page URLs (with <code>lastmod</code>) discovered in the sitemaps. This is much faster and lighter, but the output will not contain the <code>status</code> field.",
+            "default": false,
+            "editor": "checkbox"
+        },
         "proxyConfiguration": {
             "sectionCaption": "Proxy and HTTP configuration",
             "title": "Proxy configuration",

--- a/packages/actor-scraper/sitemap-scraper/INPUT_SCHEMA.json
+++ b/packages/actor-scraper/sitemap-scraper/INPUT_SCHEMA.json
@@ -15,11 +15,11 @@
             ],
             "editor": "requestListSources"
         },
-        "skipStatusCheck": {
-            "title": "List sitemap URLs only (skip status check)",
+        "checkPageStatus": {
+            "title": "Check page status",
             "type": "boolean",
-            "description": "By default, the Actor sends a HEAD request to every page found in the sitemaps and outputs its HTTP status code. Enable this option to skip those requests entirely and simply output the list of page URLs (with <code>lastmod</code>) discovered in the sitemaps. This is much faster and lighter, but the output will not contain the <code>status</code> field.",
-            "default": false,
+            "description": "When enabled (the default), the Actor sends a HEAD request to every page found in the sitemaps and outputs its HTTP status code. Disable this option to skip those requests entirely and simply output the list of page URLs (with <code>lastmod</code>) discovered in the sitemaps. This is much faster and lighter, but the output will not contain the <code>status</code> field.",
+            "default": true,
             "editor": "checkbox"
         },
         "proxyConfiguration": {

--- a/packages/actor-scraper/sitemap-scraper/INPUT_SCHEMA.json
+++ b/packages/actor-scraper/sitemap-scraper/INPUT_SCHEMA.json
@@ -18,7 +18,7 @@
         "checkPageStatus": {
             "title": "Check page status",
             "type": "boolean",
-            "description": "When enabled (the default), the Actor sends a HEAD request to every page found in the sitemaps and outputs its HTTP status code. Disable this option to skip those requests entirely and simply output the list of page URLs (with <code>lastmod</code>) discovered in the sitemaps. This is much faster and lighter, but the output will not contain the <code>status</code> field.",
+            "description": "When enabled (the default), the Actor sends a HEAD request to every page found in the sitemaps and outputs its HTTP status code. Disable this option to skip those requests entirely and simply output the list of page URLs (with <code>lastmod</code>) discovered in the sitemaps. This is much faster and lighter, but the output will not contain the <code>status</code> field, and <code>lastmod</code> falls back to the sitemap only (no <code>Last-Modified</code> header), so it will be <code>null</code> more often.",
             "default": true,
             "editor": "checkbox"
         },

--- a/packages/actor-scraper/sitemap-scraper/README.md
+++ b/packages/actor-scraper/sitemap-scraper/README.md
@@ -13,12 +13,12 @@ This Actor is designed to bridge the gap between discovery and crawling. By trav
 
 1.  **Input:** You provide one or more "Start URLs" pointing to the domain name root, sitemaps or sitemap indexes.
 2.  **Extraction:** The Actor parses the XML, extracting both page URLs and links to further sitemaps.
-3.  **Validation:** For every page URL found, the Actor performs a status check (unless **List sitemap URLs only** is enabled, see below).
+3.  **Validation:** For every page URL found, the Actor performs a status check (unless **Check page status** is disabled, see below).
 4.  **Deduplication:** The crawler uses unique keys to ensure that even if a URL appears in multiple sitemaps, it is only checked once.
 
-## List sitemap URLs only
+## Listing sitemap URLs without status checks
 
-By default, the Actor sends an HTTP HEAD request to every page found in the sitemaps and reports its status code. If you only need the list of URLs contained in the sitemaps and don't care about status codes, enable the **List sitemap URLs only (skip status check)** option. In this mode the Actor:
+By default (**Check page status** enabled), the Actor sends an HTTP HEAD request to every page found in the sitemaps and reports its status code. If you only need the list of URLs contained in the sitemaps and don't care about status codes, disable the **Check page status** option. In this mode the Actor:
 
 - does **not** send any request to the individual pages. It only downloads and parses the sitemaps themselves;
 - outputs each discovered URL together with its `lastmod` value taken from the sitemap;
@@ -33,7 +33,7 @@ For each page URL, the Actor outputs:
 | Field    |                                       Description                                       |
 | :------- | :-------------------------------------------------------------------------------------: |
 | `url`    |                                The page URL from the sitemap.                           |
-| `status` | The HTTP status code returned by the HEAD request. Omitted when **List sitemap URLs only** is enabled. |
+| `status` | The HTTP status code returned by the HEAD request. Omitted when **Check page status** is disabled. |
 | `lastmod` | Best-effort last-modification time (ISO 8601). See the note below.                      |
 
 ### A note on last-modification data
@@ -45,7 +45,7 @@ The `lastmod` field is a single best-effort timestamp derived from two sources, 
 
 **We cannot guarantee that this information is available.** Both sources are optional: many sitemaps omit `<lastmod>` entirely, and a lot of servers don't send a `Last-Modified` header (this is especially common for dynamically generated pages). When neither source provides a value, `lastmod` is `null`. Even when present, the value is self-reported by the site and may not reflect the true last-modification time of the content.
 
-When **List sitemap URLs only** is enabled, no page requests are made, so only the first source (the sitemap's `<lastmod>` tag) is used.
+When **Check page status** is disabled, no page requests are made, so only the first source (the sitemap's `<lastmod>` tag) is used.
 
 ## Usage
 

--- a/packages/actor-scraper/sitemap-scraper/README.md
+++ b/packages/actor-scraper/sitemap-scraper/README.md
@@ -13,8 +13,18 @@ This Actor is designed to bridge the gap between discovery and crawling. By trav
 
 1.  **Input:** You provide one or more "Start URLs" pointing to the domain name root, sitemaps or sitemap indexes.
 2.  **Extraction:** The Actor parses the XML, extracting both page URLs and links to further sitemaps.
-3.  **Validation:** For every page URL found, the Actor performs a status check.
+3.  **Validation:** For every page URL found, the Actor performs a status check (unless **List sitemap URLs only** is enabled, see below).
 4.  **Deduplication:** The crawler uses unique keys to ensure that even if a URL appears in multiple sitemaps, it is only checked once.
+
+## List sitemap URLs only
+
+By default, the Actor sends an HTTP HEAD request to every page found in the sitemaps and reports its status code. If you only need the list of URLs contained in the sitemaps and don't care about status codes, enable the **List sitemap URLs only (skip status check)** option. In this mode the Actor:
+
+- does **not** send any request to the individual pages. It only downloads and parses the sitemaps themselves;
+- outputs each discovered URL together with its `lastmod` value taken from the sitemap;
+- omits the `status` field from the output.
+
+This is dramatically faster and lighter on large sites, since it replaces one request per page with just a handful of requests for the sitemap files.
 
 ## Output
 
@@ -23,7 +33,7 @@ For each page URL, the Actor outputs:
 | Field    |                                       Description                                       |
 | :------- | :-------------------------------------------------------------------------------------: |
 | `url`    |                                The page URL from the sitemap.                           |
-| `status` |                       The HTTP status code returned by the HEAD request.                |
+| `status` | The HTTP status code returned by the HEAD request. Omitted when **List sitemap URLs only** is enabled. |
 | `lastmod` | Best-effort last-modification time (ISO 8601). See the note below.                      |
 
 ### A note on last-modification data
@@ -34,6 +44,8 @@ The `lastmod` field is a single best-effort timestamp derived from two sources, 
 2.  The `Last-Modified` HTTP header returned by the page (used only when the sitemap has no `<lastmod>`).
 
 **We cannot guarantee that this information is available.** Both sources are optional: many sitemaps omit `<lastmod>` entirely, and a lot of servers don't send a `Last-Modified` header (this is especially common for dynamically generated pages). When neither source provides a value, `lastmod` is `null`. Even when present, the value is self-reported by the site and may not reflect the true last-modification time of the content.
+
+When **List sitemap URLs only** is enabled, no page requests are made, so only the first source (the sitemap's `<lastmod>` tag) is used.
 
 ## Usage
 

--- a/packages/actor-scraper/sitemap-scraper/README.md
+++ b/packages/actor-scraper/sitemap-scraper/README.md
@@ -21,7 +21,7 @@ This Actor is designed to bridge the gap between discovery and crawling. By trav
 By default (**Check page status** enabled), the Actor sends an HTTP HEAD request to every page found in the sitemaps and reports its status code. If you only need the list of URLs contained in the sitemaps and don't care about status codes, disable the **Check page status** option. In this mode the Actor:
 
 - does **not** send any request to the individual pages. It only downloads and parses the sitemaps themselves;
-- outputs each discovered URL together with its `lastmod` value taken from the sitemap;
+- outputs each discovered URL with the `lastmod` value from the sitemap's `<lastmod>` tag, whenever the sitemap provides one. Since no pages are requested, the `Last-Modified` header fallback is not used, so URLs whose sitemap entry has no `<lastmod>` will have `lastmod: null`;
 - omits the `status` field from the output.
 
 This is dramatically faster and lighter on large sites, since it replaces one request per page with just a handful of requests for the sitemap files.

--- a/packages/actor-scraper/sitemap-scraper/src/internals/consts.ts
+++ b/packages/actor-scraper/sitemap-scraper/src/internals/consts.ts
@@ -27,7 +27,7 @@ export interface Input {
     proxyRotation: ProxyRotation;
     maxRequestRetries: number;
     maxCrawlingDepth: number;
-    skipStatusCheck: boolean;
+    checkPageStatus: boolean;
     debugLog: boolean;
     customData: Dictionary;
 }

--- a/packages/actor-scraper/sitemap-scraper/src/internals/consts.ts
+++ b/packages/actor-scraper/sitemap-scraper/src/internals/consts.ts
@@ -27,6 +27,7 @@ export interface Input {
     proxyRotation: ProxyRotation;
     maxRequestRetries: number;
     maxCrawlingDepth: number;
+    skipStatusCheck: boolean;
     debugLog: boolean;
     customData: Dictionary;
 }

--- a/packages/actor-scraper/sitemap-scraper/src/internals/crawler_setup.ts
+++ b/packages/actor-scraper/sitemap-scraper/src/internals/crawler_setup.ts
@@ -390,10 +390,10 @@ export class CrawlerSetup {
 
         const flushUrls = async () => {
             if (pages.length === 0) return;
-            if (this.input.skipStatusCheck) {
-                await this._outputSitemapPages(pages);
-            } else {
+            if (this.input.checkPageStatus) {
                 await this._enqueuePageRequests(pages, crawlingContext);
+            } else {
+                await this._outputSitemapPages(pages);
             }
             pages.length = 0;
         };
@@ -594,7 +594,7 @@ export class CrawlerSetup {
     }
 
     /**
-     * When `skipStatusCheck` is enabled, page URLs discovered in a sitemap are
+     * When `checkPageStatus` is disabled, page URLs discovered in a sitemap are
      * pushed directly to the dataset without sending a HEAD request per page.
      */
     private async _outputSitemapPages(pages: SitemapPageEntry[]) {

--- a/packages/actor-scraper/sitemap-scraper/src/internals/crawler_setup.ts
+++ b/packages/actor-scraper/sitemap-scraper/src/internals/crawler_setup.ts
@@ -390,7 +390,11 @@ export class CrawlerSetup {
 
         const flushUrls = async () => {
             if (pages.length === 0) return;
-            await this._enqueuePageRequests(pages, crawlingContext);
+            if (this.input.skipStatusCheck) {
+                await this._outputSitemapPages(pages);
+            } else {
+                await this._enqueuePageRequests(pages, crawlingContext);
+            }
             pages.length = 0;
         };
 
@@ -587,6 +591,26 @@ export class CrawlerSetup {
 
     private hasGzipMagicBytes(body: Buffer): boolean {
         return body.length >= 2 && body[0] === 0x1f && body[1] === 0x8b;
+    }
+
+    /**
+     * When `skipStatusCheck` is enabled, page URLs discovered in a sitemap are
+     * pushed directly to the dataset without sending a HEAD request per page.
+     */
+    private async _outputSitemapPages(pages: SitemapPageEntry[]) {
+        const items = pages.map((page) => ({
+            url: page.url,
+            lastmod: page.lastmod ?? null,
+        }));
+
+        await this.dataset.pushData(items);
+
+        for (let i = 0; i < items.length; i++) {
+            if (this.pagesOutputted > 0 && this.pagesOutputted % 100 === 0) {
+                log.info(`Pushed ${this.pagesOutputted} items to the dataset so far.`);
+            }
+            this.pagesOutputted++;
+        }
     }
 
     private async _enqueuePageRequests(pages: SitemapPageEntry[], { request, enqueueLinks }: HttpCrawlingContext) {


### PR DESCRIPTION
Adds a checkPageStatus input (default true). When disabled, the Actor skips the per-page HEAD requests and just outputs the list of URLs discovered in the sitemaps ({ url, lastmod }, no status). Default behavior is unchanged.

Closes #296 