### PR TITLE
feat: add output schema for generic scrapers

### DIFF
--- a/packages/actor-scraper/camoufox-scraper/.actor/actor.json
+++ b/packages/actor-scraper/camoufox-scraper/.actor/actor.json
@@ -3,6 +3,7 @@
     "name": "camoufox-scraper",
     "version": "0.1",
     "buildTag": "latest",
+    "output": "./output_schema.json",
     "dockerContextDir": "../../../..",
     "dockerfile": "../Dockerfile",
     "storages": {

--- a/packages/actor-scraper/camoufox-scraper/.actor/output_schema.json
+++ b/packages/actor-scraper/camoufox-scraper/.actor/output_schema.json
@@ -1,0 +1,13 @@
+{
+    "actorOutputSchemaVersion": 1,
+    "title": "Camoufox Scraper Output",
+    "description": "Links to the default dataset containing the results of the Page function.",
+    "properties": {
+        "results": {
+            "type": "string",
+            "title": "Results",
+            "description": "Dataset items returned by the Page function, each with the #error flag and #debug request metadata.",
+            "template": "{{links.apiDefaultDatasetUrl}}/items"
+        }
+    }
+}

--- a/packages/actor-scraper/cheerio-scraper/.actor/actor.json
+++ b/packages/actor-scraper/cheerio-scraper/.actor/actor.json
@@ -3,6 +3,7 @@
     "name": "cheerio-scraper",
     "version": "0.1",
     "buildTag": "latest",
+    "output": "./output_schema.json",
     "dockerContextDir": "../../../..",
     "dockerfile": "../Dockerfile",
     "storages": {

--- a/packages/actor-scraper/cheerio-scraper/.actor/output_schema.json
+++ b/packages/actor-scraper/cheerio-scraper/.actor/output_schema.json
@@ -1,0 +1,13 @@
+{
+    "actorOutputSchemaVersion": 1,
+    "title": "Cheerio Scraper Output",
+    "description": "Links to the default dataset containing the results of the Page function.",
+    "properties": {
+        "results": {
+            "type": "string",
+            "title": "Results",
+            "description": "Dataset items returned by the Page function, each with the #error flag and #debug request metadata.",
+            "template": "{{links.apiDefaultDatasetUrl}}/items"
+        }
+    }
+}

--- a/packages/actor-scraper/jsdom-scraper/.actor/actor.json
+++ b/packages/actor-scraper/jsdom-scraper/.actor/actor.json
@@ -3,6 +3,7 @@
     "name": "jsdom-scraper",
     "version": "0.1",
     "buildTag": "latest",
+    "output": "./output_schema.json",
     "dockerContextDir": "../../../..",
     "dockerfile": "../Dockerfile",
     "storages": {

--- a/packages/actor-scraper/jsdom-scraper/.actor/output_schema.json
+++ b/packages/actor-scraper/jsdom-scraper/.actor/output_schema.json
@@ -1,0 +1,13 @@
+{
+    "actorOutputSchemaVersion": 1,
+    "title": "JSDOM Scraper Output",
+    "description": "Links to the default dataset containing the results of the Page function.",
+    "properties": {
+        "results": {
+            "type": "string",
+            "title": "Results",
+            "description": "Dataset items returned by the Page function, each with the #error flag and #debug request metadata.",
+            "template": "{{links.apiDefaultDatasetUrl}}/items"
+        }
+    }
+}

--- a/packages/actor-scraper/playwright-scraper/.actor/actor.json
+++ b/packages/actor-scraper/playwright-scraper/.actor/actor.json
@@ -3,6 +3,7 @@
     "name": "playwright-scraper",
     "version": "0.1",
     "buildTag": "latest",
+    "output": "./output_schema.json",
     "dockerContextDir": "../../../..",
     "dockerfile": "../Dockerfile",
     "storages": {

--- a/packages/actor-scraper/playwright-scraper/.actor/output_schema.json
+++ b/packages/actor-scraper/playwright-scraper/.actor/output_schema.json
@@ -1,0 +1,13 @@
+{
+    "actorOutputSchemaVersion": 1,
+    "title": "Playwright Scraper Output",
+    "description": "Links to the default dataset containing the results of the Page function.",
+    "properties": {
+        "results": {
+            "type": "string",
+            "title": "Results",
+            "description": "Dataset items returned by the Page function, each with the #error flag and #debug request metadata.",
+            "template": "{{links.apiDefaultDatasetUrl}}/items"
+        }
+    }
+}

--- a/packages/actor-scraper/puppeteer-scraper/.actor/actor.json
+++ b/packages/actor-scraper/puppeteer-scraper/.actor/actor.json
@@ -3,6 +3,7 @@
     "name": "puppeteer-scraper",
     "version": "0.1",
     "buildTag": "latest",
+    "output": "./output_schema.json",
     "dockerContextDir": "../../../..",
     "dockerfile": "../Dockerfile",
     "storages": {

--- a/packages/actor-scraper/puppeteer-scraper/.actor/output_schema.json
+++ b/packages/actor-scraper/puppeteer-scraper/.actor/output_schema.json
@@ -1,0 +1,13 @@
+{
+    "actorOutputSchemaVersion": 1,
+    "title": "Puppeteer Scraper Output",
+    "description": "Links to the default dataset containing the results of the Page function.",
+    "properties": {
+        "results": {
+            "type": "string",
+            "title": "Results",
+            "description": "Dataset items returned by the Page function, each with the #error flag and #debug request metadata.",
+            "template": "{{links.apiDefaultDatasetUrl}}/items"
+        }
+    }
+}

--- a/packages/actor-scraper/web-scraper/.actor/actor.json
+++ b/packages/actor-scraper/web-scraper/.actor/actor.json
@@ -3,6 +3,7 @@
     "name": "web-scraper",
     "version": "0.1",
     "buildTag": "latest",
+    "output": "./output_schema.json",
     "dockerContextDir": "../../../..",
     "dockerfile": "../Dockerfile",
     "storages": {

--- a/packages/actor-scraper/web-scraper/.actor/output_schema.json
+++ b/packages/actor-scraper/web-scraper/.actor/output_schema.json
@@ -1,0 +1,13 @@
+{
+    "actorOutputSchemaVersion": 1,
+    "title": "Web Scraper Output",
+    "description": "Links to the default dataset containing the results of the Page function.",
+    "properties": {
+        "results": {
+            "type": "string",
+            "title": "Results",
+            "description": "Dataset items returned by the Page function, each with the #error flag and #debug request metadata.",
+            "template": "{{links.apiDefaultDatasetUrl}}/items"
+        }
+    }
+}


### PR DESCRIPTION
Added .actor/output_schema.json, each links to the default dataset via {{links.apiDefaultDatasetUrl}}/items, same as Sitemap Extractor already does.

Dataset schema stays empty on purpose: item structure is defined by the user's pageFunction, so there's nothing to list in fields. The output schema doesn't need it.

Closes #343