### PR TITLE
fix(scraper-tools): restore saveSnapshot() under content-type v2

### DIFF
--- a/packages/actor-scraper/web-scraper/src/internals/crawler_setup.ts
+++ b/packages/actor-scraper/web-scraper/src/internals/crawler_setup.ts
@@ -24,7 +24,7 @@ import {
 import type { ApifyEnv } from 'apify';
 import { Actor } from 'apify';
 import type { HTTPResponse, Page } from 'puppeteer';
-import contentType from 'content-type';
+import { parse as parseContentType } from 'content-type';
 // @ts-expect-error no typings
 import DevToolsServer from 'devtools-server';
 import { getInjectableScript } from 'idcac-playwright';
@@ -660,7 +660,7 @@ export class CrawlerSetup implements CrawlerSetupOptions {
 
         const cTypeHeader = response.headers()['content-type'];
         try {
-            const { type } = contentType.parse(cTypeHeader);
+            const { type } = parseContentType(cTypeHeader);
             if (!/^(text|application)\/xml$|\+xml$/.test(type)) return;
         } catch {
             // Invalid type is not XML.

--- a/packages/scraper-tools/src/context.ts
+++ b/packages/scraper-tools/src/context.ts
@@ -11,7 +11,7 @@ import type { Dictionary } from '@crawlee/utils';
 import type { ApifyEnv } from 'apify';
 import { Actor } from 'apify';
 import type { ContentType } from 'content-type';
-import contentTypeParser from 'content-type';
+import { format as formatContentType } from 'content-type';
 
 import log from '@apify/log';
 
@@ -114,7 +114,7 @@ class Context<
         return saveSnapshot({
             page: this.page as SnapshotOptions['page'],
             body: this.body as SnapshotOptions['body'],
-            contentType: this.contentType ? contentTypeParser.format(this.contentType as ContentType) : null,
+            contentType: this.contentType ? formatContentType(this.contentType as ContentType) : null,
             json: this.json,
         });
     }


### PR DESCRIPTION
context: https://apify.slack.com/archives/C09TL7LMJE9/p1788355444863089

content-type v2 marks its CommonJS output `__esModule` without exporting a default, so `__importDefault` left `.default` undefined and every `context.saveSnapshot()` call threw. A named import emits a plain `require`
with no interop shim. Introduced by the `^1.0.5` -> `^2.0.0` bump in #347, shipped to Cheerio and jsdom Scraper in the 2026-08-31 stable builds.